### PR TITLE
refactor: rename insight layer to episode throughout codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,11 @@ test: add conflict resolution integration tests
 
 ## Architecture
 
-The three-layer graph (Facts → Insights → Sentences) is the core invariant.
+The three-layer graph (Facts → Episodes → Sentences) is the core invariant.
 See `VEKTORI_TECHNICAL_SPEC.md` for full architecture docs.
 
 - **L0 Facts**: Primary search surface, vector search lands here.
-- **L1 Insights**: Discovered via `insight_facts` graph traversal, not vector search.
+- **L1 Episodes**: Discovered via `episode_facts` graph traversal, not vector search.
 - **L2 Sentences**: Raw conversation, sequential `NEXT` edges within sessions.
 
 Do not break this layering without discussion.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ async def main():
 
     for fact in results["facts"]:
         print(f"[{fact['score']:.2f}] {fact['text']}")
-    for insight in results["insights"]:
-        print(f"episode: {insight['text']}")
+    for episode in results["episodes"]:
+        print(f"episode: {episode['text']}")
 
     await v.close()
 
@@ -147,7 +147,7 @@ async def chat(user_id: str):
         # 1. Pull relevant memory
         mem = await v.search(query=user_input, user_id=user_id, depth="l1")
         facts = "\n".join(f"- {f['text']}" for f in mem.get("facts", []))
-        episodes = "\n".join(f"- {i['text']}" for i in mem.get("insights", []))
+        episodes = "\n".join(f"- {ep['text']}" for ep in mem.get("episodes", []))
 
         # 2. Inject into system prompt
         system = "You are a helpful assistant with memory.\n"

--- a/benchmarks/locomo/locomo_runner.py
+++ b/benchmarks/locomo/locomo_runner.py
@@ -375,7 +375,7 @@ class LoCoMoBenchmark:
                 f"{msg['role'].upper()}: {msg['content']}" for msg in session
             )
             try:
-                await extractor._extract_insights(
+                await extractor._extract_episodes(
                     inserted_facts=inserted_facts,
                     conversation=conversation,
                     session_id=haystack_sid,
@@ -697,7 +697,7 @@ def _format_retrieved_context(search_results: Any) -> str:
                 date_prefix = f"[{str(ts)[:10]}] "
             lines.append(f"{i}. {date_prefix}{fact.get('text', str(fact))}")
 
-    episodes = search_results.get("insights") or []
+    episodes = search_results.get("episodes") or []
     if episodes:
         lines.append("\n## Episodes")
         for i, ep in enumerate(episodes, 1):

--- a/benchmarks/longmemeval/longmemeval_runner.py
+++ b/benchmarks/longmemeval/longmemeval_runner.py
@@ -297,7 +297,7 @@ class LongMemEvalBenchmark:
                 f"{msg['role'].upper()}: {msg['content']}" for msg in session
             )
             try:
-                await extractor._extract_insights(
+                await extractor._extract_episodes(
                     inserted_facts=inserted_facts,
                     conversation=conversation,
                     session_id=haystack_sid,
@@ -402,7 +402,7 @@ class LongMemEvalBenchmark:
                     date_prefix = f"[{str(ts)[:10]}] "
                 lines.append(f"{i}. {date_prefix}{fact.get('text', str(fact))}")
 
-        episodes = search_results.get("insights") or []
+        episodes = search_results.get("episodes") or []
         if episodes:
             lines.append("\n## Episodes")
             for i, ep in enumerate(episodes, 1):

--- a/benchmarks/longmemeval/run_longmemeval_s.py
+++ b/benchmarks/longmemeval/run_longmemeval_s.py
@@ -76,7 +76,7 @@ async def main():
         extraction_model="gemini:gemini-2.5-flash-lite",
         
         # Retrieval
-        retrieval_depth=args.depth,  # L0=facts, L1=insights, L2=full
+        retrieval_depth=args.depth,  # L0=facts, L1=episodes, L2=full
         top_k=10,
         context_window=3,
         
@@ -100,7 +100,7 @@ async def main():
     print(f"   Dataset:      {config.dataset_name}")
     print(f"   Embedding:    {config.embedding_model} (local, no API key)")
     print(f"   Extraction:   {config.extraction_model}")
-    print(f"   Depth:        {config.retrieval_depth} (facts + insights)")
+    print(f"   Depth:        {config.retrieval_depth} (facts + episodes)")
     print(f"   Batch Size:   {config.batch_size}")
     print(f"   Workers:      {config.max_workers}")
     print(f"   Storage:      {config.storage_backend}")

--- a/examples/crewai_integration.py
+++ b/examples/crewai_integration.py
@@ -15,7 +15,7 @@ TODO: Implement full CrewAI integration.
 # async def get_memory_context(query: str, user_id: str) -> str:
 #     results = await v.search(query, user_id=user_id, depth="l1")
 #     facts = "\n".join(f"- {f['text']}" for f in results.get("facts", []))
-#     insights = "\n".join(f"- {i['text']}" for i in results.get("insights", []))
-#     return f"Facts:\n{facts}\n\nInsights:\n{insights}"
+#     episodes = "\n".join(f"- {ep['text']}" for ep in results.get("episodes", []))
+#     return f"Facts:\n{facts}\n\nEpisodes:\n{episodes}"
 
 print("CrewAI integration — TODO. See docs for integration pattern.")

--- a/examples/ollama_local.py
+++ b/examples/ollama_local.py
@@ -34,7 +34,7 @@ async def main():
         depth="l1",
     )
     print("Facts:", [f["text"] for f in results.get("facts", [])])
-    print("Insights:", [i["text"] for i in results.get("insights", [])])
+    print("Episodes:", [ep["text"] for ep in results.get("episodes", [])])
     await v.close()
 
 

--- a/examples/openai_agent.py
+++ b/examples/openai_agent.py
@@ -30,14 +30,14 @@ async def chat_with_memory(user_id: str):
         # 1. Retrieve relevant memories
         memory = await v.search(query=user_input, user_id=user_id, depth="l1")
         facts_context = "\n".join(f"- {f['text']}" for f in memory.get("facts", []))
-        insights_context = "\n".join(f"- {i['text']}" for i in memory.get("insights", []))
+        episodes_context = "\n".join(f"- {ep['text']}" for ep in memory.get("episodes", []))
 
         # 2. Build system prompt with memory context
         system = "You are a helpful assistant with access to user memory.\n"
         if facts_context:
             system += f"\nKnown facts about this user:\n{facts_context}"
-        if insights_context:
-            system += f"\nBehavioral insights:\n{insights_context}"
+        if episodes_context:
+            system += f"\nMemory episodes:\n{episodes_context}"
 
         # 3. Get response
         conversation_history.append({"role": "user", "content": user_input})

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -34,7 +34,7 @@ async def main():
 
     await asyncio.sleep(5)  # wait for async fact extraction
 
-    print("\nSearching (L1 — facts + insights)...")
+    print("\nSearching (L1 — facts + episodes)...")
     results = await v.search(
         query="How does this user prefer to communicate?",
         user_id="user-123",
@@ -45,9 +45,9 @@ async def main():
     for fact in results.get("facts", []):
         print(f"  [{fact.get('score', 0):.3f}] {fact['text']}")
 
-    print("\nInsights:")
-    for insight in results.get("insights", []):
-        print(f"  {insight['text']}")
+    print("\nEpisodes:")
+    for episode in results.get("episodes", []):
+        print(f"  {episode['text']}")
 
     await v.close()
 

--- a/examples/quickstart_postgres.py
+++ b/examples/quickstart_postgres.py
@@ -34,7 +34,7 @@ async def main():
 
         await asyncio.sleep(6)  # wait for async extraction
 
-        # L2: full story — facts + insights + source sentences + session context
+        # L2: full story — facts + episodes + source sentences + session context
         results = await v.search(
             query="What are the payment details for this user?",
             user_id="user-123",
@@ -46,9 +46,9 @@ async def main():
         for f in results.get("facts", []):
             print(f"  [{f.get('score', 0):.3f}] {f['text']}")
 
-        print("\nInsights:")
-        for i in results.get("insights", []):
-            print(f"  {i['text']}")
+        print("\nEpisodes:")
+        for ep in results.get("episodes", []):
+            print(f"  {ep['text']}")
 
         print("\nSource sentences:")
         for s in results.get("sentences", []):

--- a/tests/integration/test_ingestion.py
+++ b/tests/integration/test_ingestion.py
@@ -16,7 +16,7 @@ def _mock_vektori() -> Vektori:
     v.embedder.embed = AsyncMock(return_value=[0.1] * 1536)
     v.embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1] * 1536] * len(texts))
     v.llm = MagicMock()
-    v.llm.generate = AsyncMock(return_value='{"facts": [], "insights": []}')
+    v.llm.generate = AsyncMock(return_value='{"facts": [], "episodes": []}')
     v.db = MemoryBackend()
     v._extractor = FactExtractor(db=v.db, embedder=v.embedder, llm=v.llm)
     v._search = SearchPipeline(db=v.db, embedder=v.embedder)

--- a/tests/integration/test_retrieval.py
+++ b/tests/integration/test_retrieval.py
@@ -30,21 +30,21 @@ async def search_with_facts():
     return pipeline, db
 
 
-async def test_l0_returns_facts_and_insights(search_with_facts):
+async def test_l0_returns_facts_and_episodes(search_with_facts):
     pipeline, db = search_with_facts
     results = await pipeline.search("communication preference", "u1", depth="l0")
     assert "facts" in results
-    assert "insights" in results
-    assert isinstance(results["insights"], list)
+    assert "episodes" in results
+    assert isinstance(results["episodes"], list)
     assert len(results["facts"]) >= 1
 
 
-async def test_l1_returns_facts_insights_and_sentences(search_with_facts):
+async def test_l1_returns_facts_episodes_and_sentences(search_with_facts):
     pipeline, db = search_with_facts
     results = await pipeline.search("communication preference", "u1", depth="l1")
     assert "facts" in results
-    assert "insights" in results
-    assert isinstance(results["insights"], list)
+    assert "episodes" in results
+    assert isinstance(results["episodes"], list)
     assert len(results["facts"]) >= 1
 
 

--- a/tests/integration/test_tiered.py
+++ b/tests/integration/test_tiered.py
@@ -48,14 +48,14 @@ async def populated_pipeline():
 async def test_l0_depth(populated_pipeline):
     results = await populated_pipeline.search("WhatsApp preference", "u1", depth="l0")
     assert "facts" in results
-    assert "insights" in results
+    assert "episodes" in results
     assert "sentences" not in results
 
 
 async def test_l1_depth(populated_pipeline):
     results = await populated_pipeline.search("WhatsApp preference", "u1", depth="l1")
     assert "facts" in results
-    assert "insights" in results
+    assert "episodes" in results
     assert "sentences" in results  # L1 returns source sentences (exact origin of each fact)
 
 

--- a/vektori/client.py
+++ b/vektori/client.py
@@ -17,7 +17,7 @@ class Vektori:
 
     Stores conversational context in a three-layer sentence graph:
       L0 — Facts: primary vector search surface (short, crisp, LLM-extracted)
-      L1 — Insights: cross-session patterns, discovered via graph traversal
+      L1 — Episodes: cross-session narratives, discovered via graph traversal
       L2 — Sentences: raw conversation with sequential NEXT edges
 
     Usage:
@@ -131,7 +131,7 @@ class Vektori:
           split → quality filter → embed → upsert sentences + NEXT edges
 
         Async path (background — user does NOT wait):
-          LLM fact + insight extraction → conflict resolution → store facts/insights
+          LLM fact + episode extraction → conflict resolution → store facts/episodes
 
         Args:
             messages: [{"role": "user"|"assistant", "content": "..."}]

--- a/vektori/config.py
+++ b/vektori/config.py
@@ -28,7 +28,7 @@ class VektoriConfig:
     embedding_model: str = "openai:text-embedding-3-small"
     embedding_dimension: int = 1536
 
-    # LLM provider for fact + insight extraction
+    # LLM provider for fact + episode extraction
     extraction_model: str = "openai:gpt-4o-mini"
 
     # Quality filtering

--- a/vektori/ingestion/extractor.py
+++ b/vektori/ingestion/extractor.py
@@ -62,7 +62,7 @@ General:
 Return ONLY the JSON."""
 
 
-INSIGHTS_PROMPT = """You are writing episodic memory records. Given this conversation and the facts extracted from it, write a concise third-person narrative episode describing what happened.
+EPISODES_PROMPT = """You are writing episodic memory records. Given this conversation and the facts extracted from it, write a concise third-person narrative episode describing what happened.
 
 {session_date_line}CONVERSATION:
 {conversation}
@@ -91,7 +91,7 @@ Rules:
   GOOD: "On 2025-08-20, the user reported sustaining a Grade II ankle sprain during a badminton session. A doctor confirmed the diagnosis and provided preliminary treatment. The user requested a recovery plan."
   BAD:  "User seems to be dealing with a sports injury" ← that is a theme, not an episode
   BAD:  "User said X, assistant said Y" ← that is a transcript summary, not an episode
-- One episode per distinct topic in the batch; {max_insights} maximum
+- One episode per distinct topic in the batch; {max_episodes} maximum
 - Return {{"episodes": []}} if nothing notable
 
 Return ONLY the JSON."""
@@ -176,10 +176,10 @@ class FactExtractor:
             _inserted_facts_out=inserted_facts,
         )
 
-        insights_created = 0
+        episodes_created = 0
         if inserted_facts:
             try:
-                insights_created = await self._extract_insights(
+                episodes_created = await self._extract_episodes(
                     inserted_facts,
                     conversation,
                     session_id,
@@ -188,15 +188,15 @@ class FactExtractor:
                     session_time=session_time,
                 )
             except Exception as e:
-                logger.warning("Insight extraction failed for session %s: %s", session_id, e)
+                logger.warning("Episode extraction failed for session %s: %s", session_id, e)
 
         logger.info(
-            "Extraction complete for session %s: %d facts, %d insights",
+            "Extraction complete for session %s: %d facts, %d episodes",
             session_id,
             facts_inserted,
-            insights_created,
+            episodes_created,
         )
-        return {"facts_inserted": facts_inserted, "insights_created": insights_created}
+        return {"facts_inserted": facts_inserted, "episodes_created": episodes_created}
 
     # ── LLM Call ──────────────────────────────────────────────────────────────
 
@@ -504,14 +504,14 @@ class FactExtractor:
             logger.warning("Dedup lookup failed: %s", e)
         return None
 
-    async def _extract_insights(
+    async def _extract_episodes(
         self,
         inserted_facts: list[tuple[str, str]],
         conversation: str,
         session_id: str,
         user_id: str,
         agent_id: str | None,
-        max_insights: int = 5,
+        max_episodes: int = 5,
         session_time: datetime | None = None,
     ) -> int:
         """Extract episodic memory narratives from the conversation and its facts.
@@ -519,7 +519,7 @@ class FactExtractor:
         Episodes are concise third-person narratives of what happened in this
         session batch — grounded stories with resolved entities and dates. They
         are vector-embedded so they can be found both via graph traversal (fact →
-        insight_facts → insights) and direct cosine search at retrieval.
+        episode_facts → episodes) and direct cosine search at retrieval.
 
         Returns the number of episodes inserted.
         """
@@ -535,42 +535,42 @@ class FactExtractor:
         session_date_line = (
             f"SESSION DATE: {session_time.strftime('%Y-%m-%d')}\n\n" if session_time else ""
         )
-        prompt = INSIGHTS_PROMPT.format(
+        prompt = EPISODES_PROMPT.format(
             conversation=conv_snippet,
             facts_list=facts_list,
-            max_insights=max_insights,
+            max_episodes=max_episodes,
             session_date_line=session_date_line,
         )
         try:
             response = await self.llm.generate(prompt, max_tokens=1024)
             data = _parse_json_response(response)
         except Exception as e:
-            logger.warning("Insight LLM call failed: %s", e)
+            logger.warning("Episode LLM call failed: %s", e)
             return 0
 
-        raw_insights = data.get("episodes", data.get("insights", []))[:max_insights]
-        if not raw_insights:
+        raw_episodes = data.get("episodes", [])[:max_episodes]
+        if not raw_episodes:
             return 0
 
-        # Batch embed all insight texts in one call
-        insight_texts = [(ins.get("text") or "").strip() for ins in raw_insights]
-        insight_texts = [t for t in insight_texts if t]
-        if not insight_texts:
+        # Batch embed all episode texts in one call
+        episode_texts = [(ep.get("text") or "").strip() for ep in raw_episodes]
+        episode_texts = [t for t in episode_texts if t]
+        if not episode_texts:
             return 0
 
         try:
-            embeddings = await self.embedder.embed_batch(insight_texts)
+            embeddings = await self.embedder.embed_batch(episode_texts)
         except Exception as e:
-            logger.warning("Batch embed failed for insights: %s", e)
+            logger.warning("Batch embed failed for episodes: %s", e)
             return 0
 
-        insights_created = 0
-        text_iter = iter(zip(insight_texts, embeddings))
-        for insight_data in raw_insights:
-            text = (insight_data.get("text") or "").strip()
+        episodes_created = 0
+        text_iter = iter(zip(episode_texts, embeddings))
+        for episode_data in raw_episodes:
+            text = (episode_data.get("text") or "").strip()
             if not text:
                 continue
-            indices = insight_data.get("fact_indices") or []
+            indices = episode_data.get("fact_indices") or []
 
             try:
                 _, embedding = next(text_iter)
@@ -587,16 +587,16 @@ class FactExtractor:
                 continue
 
             try:
-                insight_id = await self.db.insert_insight(
+                episode_id = await self.db.insert_episode(
                     text, embedding, user_id, agent_id, session_id
                 )
                 for fid in linked_ids:
-                    await self.db.insert_insight_fact(insight_id, fid)
-                insights_created += 1
+                    await self.db.insert_episode_fact(episode_id, fid)
+                episodes_created += 1
             except Exception as e:
-                logger.warning("Failed to insert insight '%s': %s", text, e)
+                logger.warning("Failed to insert episode '%s': %s", text, e)
 
-        return insights_created
+        return episodes_created
 
     async def _link_to_source_sentences(
         self,

--- a/vektori/ingestion/pipeline.py
+++ b/vektori/ingestion/pipeline.py
@@ -23,7 +23,7 @@ class IngestionPipeline:
       → upsert sentences + NEXT edges → upsert session
 
     Asynchronous (background, user does NOT wait):
-      LLM fact + insight extraction via ExtractionWorker (debounced, batched)
+      LLM fact + episode extraction via ExtractionWorker (debounced, batched)
 
     If async_extraction=False, extraction runs inline (slower, for tests/simple use cases).
     """

--- a/vektori/models/anthropic.py
+++ b/vektori/models/anthropic.py
@@ -52,7 +52,7 @@ class AnthropicEmbedder(EmbeddingProvider):
 
 
 class AnthropicLLM(LLMProvider):
-    """Anthropic Claude for fact + insight extraction."""
+    """Anthropic Claude for fact + episode extraction."""
 
     def __init__(self, model: str | None = None, api_key: str | None = None) -> None:
         self.model = model or DEFAULT_LLM_MODEL

--- a/vektori/models/base.py
+++ b/vektori/models/base.py
@@ -29,7 +29,7 @@ class EmbeddingProvider(ABC):
 
 
 class LLMProvider(ABC):
-    """Abstract LLM provider for fact and insight extraction."""
+    """Abstract LLM provider for fact and episode extraction."""
 
     @abstractmethod
     async def generate(self, prompt: str, max_tokens: int | None = None) -> str:

--- a/vektori/models/gemini.py
+++ b/vektori/models/gemini.py
@@ -1,5 +1,5 @@
 """
-Google Gemini API provider for fact and insight extraction.
+Google Gemini API provider for fact and episode extraction.
 
 Direct integration with google-generativeai library.
 Supports: gemini-2-flash, gemini-2.5-flash, gemini-3-pro, etc.
@@ -39,7 +39,7 @@ DEFAULT_BACKOFF_MULTIPLIER = 2.0
 
 class GeminiLLM(LLMProvider):
     """
-    Google Gemini API provider for fact + insight extraction.
+    Google Gemini API provider for fact + episode extraction.
 
     Direct google-generativeai integration (not via LiteLLM).
     Supports all Gemini models: gemini-2-flash, gemini-2.5-flash, gemini-3-pro, etc.

--- a/vektori/models/litellm_provider.py
+++ b/vektori/models/litellm_provider.py
@@ -20,7 +20,7 @@ DEFAULT_MODEL = "gpt-4o-mini"
 
 class LiteLLMProvider(LLMProvider):
     """
-    LiteLLM-backed LLM provider for fact + insight extraction.
+    LiteLLM-backed LLM provider for fact + episode extraction.
 
     Supports any model string that LiteLLM understands:
       - "gpt-4o-mini"

--- a/vektori/models/ollama.py
+++ b/vektori/models/ollama.py
@@ -62,7 +62,7 @@ class OllamaEmbedder(EmbeddingProvider):
 
 class OllamaLLM(LLMProvider):
     """
-    Ollama local LLM for fact + insight extraction.
+    Ollama local LLM for fact + episode extraction.
 
     Prerequisites:
         ollama pull llama3

--- a/vektori/models/openai.py
+++ b/vektori/models/openai.py
@@ -54,7 +54,7 @@ class OpenAIEmbedder(EmbeddingProvider):
 
 
 class OpenAILLM(LLMProvider):
-    """OpenAI chat completion for fact + insight extraction."""
+    """OpenAI chat completion for fact + episode extraction."""
 
     def __init__(self, model: str | None = None, api_key: str | None = None) -> None:
         self.model = model or DEFAULT_LLM_MODEL

--- a/vektori/retrieval/search.py
+++ b/vektori/retrieval/search.py
@@ -24,10 +24,10 @@ class SearchPipeline:
         Vector search over facts. Entry point for all retrieval.
         Facts are short and crisp → best cosine match for direct queries.
 
-    L1 — Facts + Insights + Source Sentences (~300-800 tokens):
-        Facts + cross-session insights linked to those facts (via insight_facts graph
+    L1 — Facts + Episodes + Source Sentences (~300-800 tokens):
+        Facts + cross-session episodes linked to those facts (via episode_facts graph
         traversal) + the exact sentences each fact was extracted from (via fact_sources).
-        Insights are always returned at every depth; sentences require l1 or l2.
+        Episodes are always returned at every depth; sentences require l1 or l2.
         This is the default depth.
 
     L2 — Full story (~1000-3000 tokens):
@@ -90,7 +90,7 @@ class SearchPipeline:
             user_id: Whose memories to search.
             agent_id: Optional agent scoping. None means search all agents.
             depth: "l0" | "l1" | "l2". Invalid values raise ValueError.
-            top_k: Max facts to return. Insights and sentences are not capped
+            top_k: Max facts to return. Episodes and sentences are not capped
                    here — they're derived from the returned facts and bounded
                    by how many links exist in the graph.
             context_window: ±N sentences around each source sentence (L2 only).
@@ -103,7 +103,7 @@ class SearchPipeline:
         Returns:
             {
               "facts":        list[dict],  # always present
-              "insights":     list[dict],  # always present — cross-session patterns linked to matched facts
+              "episodes":     list[dict],  # always present — cross-session patterns linked to matched facts
               "sentences":    list[dict],  # l1, l2 only
               "memory_found": bool,        # False when no facts passed min_score (abstention signal)
             }
@@ -206,10 +206,10 @@ class SearchPipeline:
         if not seed_facts:
             logger.debug("search: no facts for user=%s, falling back to sentence search", user_id)
             if depth == "l0":
-                return {"facts": [], "insights": [], "memory_found": False}
+                return {"facts": [], "episodes": [], "memory_found": False}
             return {
                 "facts": [],
-                "insights": [],
+                "episodes": [],
                 "sentences": direct_sentences,
                 "memory_found": False,
             }
@@ -233,25 +233,25 @@ class SearchPipeline:
 
         if depth == "l0":
             # L0: graph traversal only — keep it light
-            insights = await self.db.get_insights_for_facts(seed_fact_ids)
+            episodes = await self.db.get_episodes_for_facts(seed_fact_ids)
             top = _clean(top_k_facts)
-            return {"facts": top, "insights": insights, "memory_found": len(top) > 0}
+            return {"facts": top, "episodes": episodes, "memory_found": len(top) > 0}
 
-        # ── Step 2: Insights (L1/L2) — graph traversal + vector search ────────
+        # ── Step 2: Episodes (L1/L2) — graph traversal + vector search ────────
         # Run both concurrently: graph edges from matched facts, and direct
-        # cosine search over insight embeddings. Merge by ID so the same
-        # insight doesn't appear twice.
-        graph_insights, vec_insights = await asyncio.gather(
-            self.db.get_insights_for_facts(seed_fact_ids),
-            self.db.search_insights(query_embedding, user_id, agent_id),
+        # cosine search over episode embeddings. Merge by ID so the same
+        # episode doesn't appear twice.
+        graph_episodes, vec_episodes = await asyncio.gather(
+            self.db.get_episodes_for_facts(seed_fact_ids),
+            self.db.search_episodes(query_embedding, user_id, agent_id),
         )
-        seen_insight_ids: set[str] = set()
-        insights: list[dict[str, Any]] = []
-        for ins in (*graph_insights, *vec_insights):
+        seen_episode_ids: set[str] = set()
+        episodes: list[dict[str, Any]] = []
+        for ins in (*graph_episodes, *vec_episodes):
             iid = ins.get("id")
-            if iid and iid not in seen_insight_ids:
-                seen_insight_ids.add(iid)
-                insights.append(ins)
+            if iid and iid not in seen_episode_ids:
+                seen_episode_ids.add(iid)
+                episodes.append(ins)
 
         # ── Step 3: Trace facts → source sentences ────────────────────────────
         source_sentence_ids = await self.db.get_source_sentences(seed_fact_ids)
@@ -284,7 +284,7 @@ class SearchPipeline:
         if not all_candidate_ids:
             return {
                 "facts": top_facts,
-                "insights": insights,
+                "episodes": episodes,
                 "sentences": [],
                 "memory_found": memory_found,
             }
@@ -337,7 +337,7 @@ class SearchPipeline:
 
         return {
             "facts": top_facts,
-            "insights": insights,
+            "episodes": episodes,
             "sentences": _dedup(result_sentences),
             "memory_found": memory_found,
         }
@@ -385,21 +385,21 @@ class SearchPipeline:
         top_facts = _clean(scored_facts[:top_k])
         top_fact_ids = [f["id"] for f in top_facts]
 
-        graph_insights, vec_insights = await asyncio.gather(
-            self.db.get_insights_for_facts(top_fact_ids),
-            self.db.search_insights(query_embedding, user_id, agent_id),
+        graph_episodes, vec_episodes = await asyncio.gather(
+            self.db.get_episodes_for_facts(top_fact_ids),
+            self.db.search_episodes(query_embedding, user_id, agent_id),
         )
-        seen_insight_ids: set[str] = set()
-        insights: list[dict[str, Any]] = []
-        for ins in (*graph_insights, *vec_insights):
+        seen_episode_ids: set[str] = set()
+        episodes: list[dict[str, Any]] = []
+        for ins in (*graph_episodes, *vec_episodes):
             iid = ins.get("id")
-            if iid and iid not in seen_insight_ids:
-                seen_insight_ids.add(iid)
-                insights.append(ins)
+            if iid and iid not in seen_episode_ids:
+                seen_episode_ids.add(iid)
+                episodes.append(ins)
 
         return {
             "facts": top_facts,
-            "insights": insights,
+            "episodes": episodes,
             "sentences": _dedup(raw.get("sentences", [])),
             "memory_found": len(top_facts) > 0,
         }
@@ -473,7 +473,7 @@ class SearchPipeline:
             logger.debug("search_expanded: no facts found, falling back to sentence search")
             return {
                 "facts": [],
-                "insights": [],
+                "episodes": [],
                 "sentences": direct_sentences,
                 "memory_found": False,
             }
@@ -495,18 +495,18 @@ class SearchPipeline:
         top_facts = scored_facts[:top_k]
         fact_ids = [f["id"] for f in top_facts]
 
-        graph_insights, vec_insights, source_sentence_ids = await asyncio.gather(
-            self.db.get_insights_for_facts(fact_ids),
-            self.db.search_insights(embeddings[0], user_id, agent_id),
+        graph_episodes, vec_episodes, source_sentence_ids = await asyncio.gather(
+            self.db.get_episodes_for_facts(fact_ids),
+            self.db.search_episodes(embeddings[0], user_id, agent_id),
             self.db.get_source_sentences(fact_ids),
         )
-        seen_insight_ids: set[str] = set()
-        insights: list[dict[str, Any]] = []
-        for ins in (*graph_insights, *vec_insights):
+        seen_episode_ids: set[str] = set()
+        episodes: list[dict[str, Any]] = []
+        for ins in (*graph_episodes, *vec_episodes):
             iid = ins.get("id")
-            if iid and iid not in seen_insight_ids:
-                seen_insight_ids.add(iid)
-                insights.append(ins)
+            if iid and iid not in seen_episode_ids:
+                seen_episode_ids.add(iid)
+                episodes.append(ins)
 
         # Session scoring: merge direct search + fact-linked sentences
         direct_sent_by_id: dict[str, dict[str, Any]] = {s["id"]: s for s in direct_sentences}
@@ -561,7 +561,7 @@ class SearchPipeline:
 
         return {
             "facts": _clean(top_facts),
-            "insights": insights,
+            "episodes": episodes,
             "sentences": _dedup(result_sentences),
             "memory_found": len(top_facts) > 0,
         }
@@ -583,7 +583,7 @@ class SearchPipeline:
         since they're stored synchronously in add().
         """
         if depth == "l0":
-            return {"facts": [], "insights": [], "memory_found": False}
+            return {"facts": [], "episodes": [], "memory_found": False}
 
         sentences = await self.db.search_sentences(
             embedding=query_embedding,
@@ -591,7 +591,7 @@ class SearchPipeline:
             agent_id=agent_id,
             limit=top_k,
         )
-        return {"facts": [], "insights": [], "sentences": sentences, "memory_found": False}
+        return {"facts": [], "episodes": [], "sentences": sentences, "memory_found": False}
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -599,7 +599,7 @@ class SearchPipeline:
 
 def _empty(depth: str) -> dict[str, Any]:
     """Return the correct empty structure for a given depth."""
-    result: dict[str, Any] = {"facts": [], "insights": []}
+    result: dict[str, Any] = {"facts": [], "episodes": []}
     if depth in ("l1", "l2"):
         result["sentences"] = []
     return result

--- a/vektori/storage/base.py
+++ b/vektori/storage/base.py
@@ -17,7 +17,7 @@ class StorageBackend(ABC):
     The interface maps directly to the two-layer graph schema:
       - Facts (L0): LLM-extracted statements, primary vector search surface
       - Sentences (L2): raw conversation nodes + NEXT edges (context expansion)
-      - Join tables: fact_sources (L0↔L2)
+      - Join tables: fact_sources (L0↔L2), episode_facts (L1↔L0)
 
     Layer numbering matches SearchPipeline depth parameter:
       L0 — vector search over facts only
@@ -58,7 +58,7 @@ class StorageBackend(ABC):
         session_id: str,
         threshold: float = 0.75,
     ) -> list[str]:
-        """Find sentence IDs semantically similar to given quotes. Used to link facts/insights to source sentences."""
+        """Find sentence IDs semantically similar to given quotes. Used to link facts/episodes to source sentences."""
         ...
 
     async def search_sentences_in_session(
@@ -196,10 +196,10 @@ class StorageBackend(ABC):
         for fact_id, sentence_id in pairs:
             await self.insert_fact_source(fact_id, sentence_id)
 
-    # ── Insights ──
+    # ── Episodes ──
 
     @abstractmethod
-    async def insert_insight(
+    async def insert_episode(
         self,
         text: str,
         embedding: list[float],
@@ -207,40 +207,40 @@ class StorageBackend(ABC):
         agent_id: str | None = None,
         session_id: str | None = None,
     ) -> str:
-        """Insert an insight and return its UUID.
+        """Insert an episode and return its UUID.
 
         Uses a deterministic ID (uuid5 of user_id+text) so inserting the same
-        insight twice is idempotent — ON CONFLICT DO NOTHING.
-        embedding: pre-computed vector of the insight text for direct vector search.
+        episode twice is idempotent — ON CONFLICT DO NOTHING.
+        embedding: pre-computed vector of the episode text for direct vector search.
         """
         ...
 
     @abstractmethod
-    async def insert_insight_fact(self, insight_id: str, fact_id: str) -> None:
-        """Link an insight to a fact it was derived from. ON CONFLICT DO NOTHING."""
+    async def insert_episode_fact(self, episode_id: str, fact_id: str) -> None:
+        """Link an episode to a fact it was derived from. ON CONFLICT DO NOTHING."""
         ...
 
     @abstractmethod
-    async def get_insights_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
-        """Return insights linked to any of the given facts via insight_facts.
+    async def get_episodes_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
+        """Return episodes linked to any of the given facts via episode_facts.
 
         Used at retrieval time to surface L1 patterns after L0 vector search.
-        Returns insight dicts with at minimum {id, text}.
+        Returns episode dicts with at minimum {id, text}.
         """
         ...
 
     @abstractmethod
-    async def search_insights(
+    async def search_episodes(
         self,
         embedding: list[float],
         user_id: str,
         agent_id: str | None = None,
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector search over insights for a user.
+        """Vector search over episodes for a user.
 
-        Complements graph traversal: surfaces insights from sessions whose facts
-        didn't land in the top-k but whose insight text is semantically close to
+        Complements graph traversal: surfaces episodes from sessions whose facts
+        didn't land in the top-k but whose episode text is semantically close to
         the query.
         """
         ...

--- a/vektori/storage/memory.py
+++ b/vektori/storage/memory.py
@@ -32,8 +32,8 @@ class MemoryBackend(StorageBackend):
         self._edges: list[dict[str, Any]] = []
         self._fact_sources: list[dict[str, str]] = []  # [{fact_id, sentence_id}]
         self._sessions: dict[str, dict[str, Any]] = {}
-        self._insights: dict[str, dict[str, Any]] = {}
-        self._insight_facts: list[dict[str, str]] = []  # [{insight_id, fact_id}]
+        self._episodes: dict[str, dict[str, Any]] = {}
+        self._episode_facts: list[dict[str, str]] = []  # [{episode_id, fact_id}]
 
     async def initialize(self) -> None:
         pass  # Nothing to do
@@ -282,9 +282,9 @@ class MemoryBackend(StorageBackend):
 
     # ── Join tables ──
 
-    # ── Insights ──
+    # ── Episodes ──
 
-    async def insert_insight(
+    async def insert_episode(
         self,
         text: str,
         embedding: list[float],
@@ -292,10 +292,10 @@ class MemoryBackend(StorageBackend):
         agent_id: str | None = None,
         session_id: str | None = None,
     ) -> str:
-        insight_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}"))
-        if insight_id not in self._insights:
-            self._insights[insight_id] = {
-                "id": insight_id,
+        episode_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}"))
+        if episode_id not in self._episodes:
+            self._episodes[episode_id] = {
+                "id": episode_id,
                 "text": text,
                 "embedding": embedding,
                 "user_id": user_id,
@@ -304,29 +304,29 @@ class MemoryBackend(StorageBackend):
                 "is_active": True,
                 "created_at": datetime.utcnow(),
             }
-        return insight_id
+        return episode_id
 
-    async def insert_insight_fact(self, insight_id: str, fact_id: str) -> None:
+    async def insert_episode_fact(self, episode_id: str, fact_id: str) -> None:
         # Dedup: don't add the same link twice
-        for link in self._insight_facts:
-            if link["insight_id"] == insight_id and link["fact_id"] == fact_id:
+        for link in self._episode_facts:
+            if link["episode_id"] == episode_id and link["fact_id"] == fact_id:
                 return
-        self._insight_facts.append({"insight_id": insight_id, "fact_id": fact_id})
+        self._episode_facts.append({"episode_id": episode_id, "fact_id": fact_id})
 
-    async def get_insights_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
+    async def get_episodes_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
         if not fact_ids:
             return []
         fact_id_set = set(fact_ids)
-        matched_insight_ids = {
-            link["insight_id"] for link in self._insight_facts if link["fact_id"] in fact_id_set
+        matched_episode_ids = {
+            link["episode_id"] for link in self._episode_facts if link["fact_id"] in fact_id_set
         }
         return [
-            {k: v for k, v in self._insights[iid].items() if k != "embedding"}
-            for iid in matched_insight_ids
-            if iid in self._insights and self._insights[iid].get("is_active", True)
+            {k: v for k, v in self._episodes[eid].items() if k != "embedding"}
+            for eid in matched_episode_ids
+            if eid in self._episodes and self._episodes[eid].get("is_active", True)
         ]
 
-    async def search_insights(
+    async def search_episodes(
         self,
         embedding: list[float],
         user_id: str,
@@ -334,18 +334,18 @@ class MemoryBackend(StorageBackend):
         limit: int = 5,
     ) -> list[dict[str, Any]]:
         results = []
-        for ins in self._insights.values():
-            if ins.get("user_id") != user_id:
+        for ep in self._episodes.values():
+            if ep.get("user_id") != user_id:
                 continue
-            if agent_id and ins.get("agent_id") != agent_id:
+            if agent_id and ep.get("agent_id") != agent_id:
                 continue
-            if not ins.get("is_active", True):
+            if not ep.get("is_active", True):
                 continue
-            emb = ins.get("embedding")
+            emb = ep.get("embedding")
             if not emb:
                 continue
             sim = _cosine_similarity(embedding, emb)
-            row = {k: v for k, v in ins.items() if k != "embedding"}
+            row = {k: v for k, v in ep.items() if k != "embedding"}
             results.append({**row, "distance": 1.0 - sim})
         results.sort(key=lambda x: x["distance"])
         return results[:limit]
@@ -423,7 +423,7 @@ class MemoryBackend(StorageBackend):
 
     async def delete_user(self, user_id: str) -> int:
         count = 0
-        for store in [self._sentences, self._facts, self._insights, self._sessions]:
+        for store in [self._sentences, self._facts, self._episodes, self._sessions]:
             keys = [k for k, v in store.items() if v.get("user_id") == user_id]
             for k in keys:
                 del store[k]

--- a/vektori/storage/postgres.py
+++ b/vektori/storage/postgres.py
@@ -515,9 +515,9 @@ class PostgresBackend(StorageBackend):
                 [(uuid.UUID(f), uuid.UUID(s)) for f, s in pairs],
             )
 
-    # ── Insights ──────────────────────────────────────────────────────────────
+    # ── Episodes ──────────────────────────────────────────────────────────────
 
-    async def insert_insight(
+    async def insert_episode(
         self,
         text: str,
         embedding: list[float],
@@ -525,53 +525,53 @@ class PostgresBackend(StorageBackend):
         agent_id: str | None = None,
         session_id: str | None = None,
     ) -> str:
-        insight_id = uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}")
+        episode_id = uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}")
         async with self._pool.acquire() as conn:
             await conn.execute(
                 """
-                INSERT INTO insights (id, text, embedding, user_id, agent_id, session_id)
+                INSERT INTO episodes (id, text, embedding, user_id, agent_id, session_id)
                 VALUES ($1, $2, $3::vector, $4, $5, $6)
                 ON CONFLICT DO NOTHING
                 """,
-                insight_id,
+                episode_id,
                 text,
                 _vec(embedding),
                 user_id,
                 agent_id,
                 session_id,
             )
-        return str(insight_id)
+        return str(episode_id)
 
-    async def insert_insight_fact(self, insight_id: str, fact_id: str) -> None:
+    async def insert_episode_fact(self, episode_id: str, fact_id: str) -> None:
         async with self._pool.acquire() as conn:
             await conn.execute(
                 """
-                INSERT INTO insight_facts (insight_id, fact_id)
+                INSERT INTO episode_facts (episode_id, fact_id)
                 VALUES ($1, $2)
                 ON CONFLICT DO NOTHING
                 """,
-                uuid.UUID(insight_id),
+                uuid.UUID(episode_id),
                 uuid.UUID(fact_id),
             )
 
-    async def get_insights_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
+    async def get_episodes_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
         if not fact_ids:
             return []
         uuid_ids = [uuid.UUID(fid) for fid in fact_ids]
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(
                 """
-                SELECT DISTINCT i.id, i.text, i.session_id, i.created_at
-                FROM insights i
-                JOIN insight_facts if2 ON i.id = if2.insight_id
-                WHERE if2.fact_id = ANY($1::uuid[])
-                  AND i.is_active = true
+                SELECT DISTINCT e.id, e.text, e.session_id, e.created_at
+                FROM episodes e
+                JOIN episode_facts ef2 ON e.id = ef2.episode_id
+                WHERE ef2.fact_id = ANY($1::uuid[])
+                  AND e.is_active = true
                 """,
                 uuid_ids,
             )
         return [_row(r) for r in rows]
 
-    async def search_insights(
+    async def search_episodes(
         self,
         embedding: list[float],
         user_id: str,
@@ -583,7 +583,7 @@ class PostgresBackend(StorageBackend):
                 """
                 SELECT id, text, session_id, created_at,
                        embedding <=> $1::vector AS distance
-                FROM insights
+                FROM episodes
                 WHERE user_id = $2
                   AND ($3::text IS NULL OR agent_id = $3)
                   AND is_active = true
@@ -712,14 +712,14 @@ class PostgresBackend(StorageBackend):
                 LIMIT $6
             ),
 
-            -- Step 2: Insights linked to matched facts (L1)
-            -- Graph traversal via insight_facts — NOT vector search.
-            related_insights AS (
-                SELECT DISTINCT i.id, i.text, i.confidence, i.created_at, i.metadata
-                FROM insights i
-                INNER JOIN insight_facts inf ON i.id = inf.insight_id
-                WHERE inf.fact_id IN (SELECT id FROM seed_facts)
-                  AND i.is_active = true
+            -- Step 2: Episodes linked to matched facts (L1)
+            -- Graph traversal via episode_facts — NOT vector search.
+            related_episodes AS (
+                SELECT DISTINCT e.id, e.text, e.confidence, e.created_at, e.metadata
+                FROM episodes e
+                INNER JOIN episode_facts ef ON e.id = ef.episode_id
+                WHERE ef.fact_id IN (SELECT id FROM seed_facts)
+                  AND e.is_active = true
             ),
 
             -- Step 3: Source sentences for matched facts
@@ -750,9 +750,9 @@ class PostgresBackend(StorageBackend):
                               metadata::text, distance
             FROM seed_facts
             UNION ALL
-            SELECT 'insight'  AS layer, id, text, confidence, NULL::integer AS mentions, created_at,
+            SELECT 'episode'  AS layer, id, text, confidence, NULL::integer AS mentions, created_at,
                               metadata::text, NULL AS distance
-            FROM related_insights
+            FROM related_episodes
             UNION ALL
             SELECT 'sentence' AS layer, id, text, NULL AS confidence, NULL::integer AS mentions, created_at,
                               NULL AS metadata, NULL AS distance
@@ -780,10 +780,11 @@ class PostgresBackend(StorageBackend):
             layer = d.pop("layer")
             if layer == "fact":
                 facts.append(d)
-            else:
+            elif layer == "sentence":
                 d.pop("distance", None)
                 d.pop("confidence", None)
                 sentences.append(d)
+            # episode rows are retrieved separately via get_episodes_for_facts
 
         return {"facts": facts, "sentences": sentences}
 
@@ -803,7 +804,7 @@ class PostgresBackend(StorageBackend):
                     SELECT
                         (SELECT COUNT(*) FROM sentences WHERE user_id = $1) +
                         (SELECT COUNT(*) FROM facts    WHERE user_id = $1) +
-                        (SELECT COUNT(*) FROM insights WHERE user_id = $1) +
+                        (SELECT COUNT(*) FROM episodes WHERE user_id = $1) +
                         (SELECT COUNT(*) FROM sessions WHERE user_id = $1) AS total
                     """,
                     user_id,
@@ -811,7 +812,7 @@ class PostgresBackend(StorageBackend):
                 total = counts["total"] if counts else 0
                 await conn.execute("DELETE FROM sentences WHERE user_id = $1", user_id)
                 await conn.execute("DELETE FROM facts    WHERE user_id = $1", user_id)
-                await conn.execute("DELETE FROM insights WHERE user_id = $1", user_id)
+                await conn.execute("DELETE FROM episodes WHERE user_id = $1", user_id)
                 await conn.execute("DELETE FROM sessions WHERE user_id = $1", user_id)
 
         logger.info("Deleted %d rows for user %s", total, user_id)

--- a/vektori/storage/schema.sql
+++ b/vektori/storage/schema.sql
@@ -130,36 +130,36 @@ CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions (user_id);
 
 
 -- ============================================================
--- INSIGHTS: The middle layer (L1). LLM-inferred cross-session patterns.
--- Not vector-searched — discovered via graph traversal from matched facts.
+-- EPISODES: The middle layer (L1). LLM-generated episodic memory narratives.
+-- Discovered via graph traversal from matched facts, also directly vector-searched.
 -- ============================================================
-CREATE TABLE IF NOT EXISTS insights (
+CREATE TABLE IF NOT EXISTS episodes (
     id UUID PRIMARY KEY,
     text TEXT NOT NULL,
     embedding vector(1536),               -- for direct vector search at retrieval
     user_id TEXT NOT NULL,
     agent_id TEXT,
-    session_id TEXT,                       -- session this insight came from
+    session_id TEXT,                       -- session this episode came from
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_insights_user ON insights (user_id);
-CREATE INDEX IF NOT EXISTS idx_insights_embedding ON insights
+CREATE INDEX IF NOT EXISTS idx_episodes_user ON episodes (user_id);
+CREATE INDEX IF NOT EXISTS idx_episodes_embedding ON episodes
     USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
--- Dedup: same insight text for same user is idempotent
-CREATE UNIQUE INDEX IF NOT EXISTS idx_insights_user_text ON insights (user_id, text);
+-- Dedup: same episode text for same user is idempotent
+CREATE UNIQUE INDEX IF NOT EXISTS idx_episodes_user_text ON episodes (user_id, text);
 
 
 -- ============================================================
--- INSIGHT_FACTS: Links insights (L1) to the facts (L0) they were derived from.
--- Graph edge: traversed after L0 vector search to surface patterns.
+-- EPISODE_FACTS: Links episodes (L1) to the facts (L0) they were derived from.
+-- Graph edge: traversed after L0 vector search to surface episodes.
 -- ============================================================
-CREATE TABLE IF NOT EXISTS insight_facts (
-    insight_id UUID NOT NULL REFERENCES insights(id) ON DELETE CASCADE,
+CREATE TABLE IF NOT EXISTS episode_facts (
+    episode_id UUID NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
     fact_id UUID NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
-    PRIMARY KEY (insight_id, fact_id)
+    PRIMARY KEY (episode_id, fact_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_insight_facts_insight ON insight_facts (insight_id);
-CREATE INDEX IF NOT EXISTS idx_insight_facts_fact ON insight_facts (fact_id);
+CREATE INDEX IF NOT EXISTS idx_episode_facts_episode ON episode_facts (episode_id);
+CREATE INDEX IF NOT EXISTS idx_episode_facts_fact ON episode_facts (fact_id);

--- a/vektori/storage/sqlite.py
+++ b/vektori/storage/sqlite.py
@@ -122,7 +122,7 @@ class SQLiteBackend(StorageBackend):
 
             CREATE INDEX IF NOT EXISTS idx_sentences_user ON sentences (user_id);
             CREATE INDEX IF NOT EXISTS idx_sentences_session ON sentences (session_id);
-            CREATE TABLE IF NOT EXISTS insights (
+            CREATE TABLE IF NOT EXISTS episodes (
                 id TEXT PRIMARY KEY,
                 text TEXT NOT NULL,
                 embedding TEXT,            -- JSON array of floats
@@ -134,16 +134,16 @@ class SQLiteBackend(StorageBackend):
                 UNIQUE (user_id, text)
             );
 
-            CREATE TABLE IF NOT EXISTS insight_facts (
-                insight_id TEXT NOT NULL REFERENCES insights(id) ON DELETE CASCADE,
+            CREATE TABLE IF NOT EXISTS episode_facts (
+                episode_id TEXT NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
                 fact_id TEXT NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
-                PRIMARY KEY (insight_id, fact_id)
+                PRIMARY KEY (episode_id, fact_id)
             );
 
             CREATE INDEX IF NOT EXISTS idx_facts_user ON facts (user_id);
             CREATE INDEX IF NOT EXISTS idx_facts_active ON facts (user_id, is_active);
             CREATE INDEX IF NOT EXISTS idx_fact_sources_fact ON fact_sources (fact_id);
-            CREATE INDEX IF NOT EXISTS idx_insight_facts_fact ON insight_facts (fact_id);
+            CREATE INDEX IF NOT EXISTS idx_episode_facts_fact ON episode_facts (fact_id);
         """)
 
     async def _migrate(self) -> None:
@@ -467,9 +467,9 @@ class SQLiteBackend(StorageBackend):
             rows = await cursor.fetchall()
         return [row[0] for row in rows]
 
-    # ── Insights ──
+    # ── Episodes ──
 
-    async def insert_insight(
+    async def insert_episode(
         self,
         text: str,
         embedding: list[float],
@@ -477,44 +477,44 @@ class SQLiteBackend(StorageBackend):
         agent_id: str | None = None,
         session_id: str | None = None,
     ) -> str:
-        insight_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}"))
+        episode_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}"))
         await self._conn.execute(
-            """INSERT OR IGNORE INTO insights (id, text, embedding, user_id, agent_id, session_id)
+            """INSERT OR IGNORE INTO episodes (id, text, embedding, user_id, agent_id, session_id)
                VALUES (?, ?, ?, ?, ?, ?)""",
-            (insight_id, text, json.dumps(embedding), user_id, agent_id, session_id),
+            (episode_id, text, json.dumps(embedding), user_id, agent_id, session_id),
         )
         await self._conn.commit()
-        return insight_id
+        return episode_id
 
-    async def insert_insight_fact(self, insight_id: str, fact_id: str) -> None:
+    async def insert_episode_fact(self, episode_id: str, fact_id: str) -> None:
         await self._conn.execute(
-            "INSERT OR IGNORE INTO insight_facts (insight_id, fact_id) VALUES (?, ?)",
-            (insight_id, fact_id),
+            "INSERT OR IGNORE INTO episode_facts (episode_id, fact_id) VALUES (?, ?)",
+            (episode_id, fact_id),
         )
         await self._conn.commit()
 
-    async def get_insights_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
+    async def get_episodes_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
         if not fact_ids:
             return []
         placeholders = ",".join("?" * len(fact_ids))
         async with self._conn.execute(
-            f"""SELECT DISTINCT i.id, i.text, i.session_id, i.created_at
-                FROM insights i
-                JOIN insight_facts if2 ON i.id = if2.insight_id
-                WHERE if2.fact_id IN ({placeholders}) AND i.is_active = 1""",
+            f"""SELECT DISTINCT e.id, e.text, e.session_id, e.created_at
+                FROM episodes e
+                JOIN episode_facts ef2 ON e.id = ef2.episode_id
+                WHERE ef2.fact_id IN ({placeholders}) AND e.is_active = 1""",
             fact_ids,
         ) as cursor:
             rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
-    async def search_insights(
+    async def search_episodes(
         self,
         embedding: list[float],
         user_id: str,
         agent_id: str | None = None,
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        query = "SELECT id, text, session_id, embedding, created_at FROM insights WHERE user_id = ? AND is_active = 1"
+        query = "SELECT id, text, session_id, embedding, created_at FROM episodes WHERE user_id = ? AND is_active = 1"
         params: list[Any] = [user_id]
         if agent_id:
             query += " AND agent_id = ?"
@@ -606,7 +606,7 @@ class SQLiteBackend(StorageBackend):
 
     async def delete_user(self, user_id: str) -> int:
         count = 0
-        for table in ["sentences", "facts", "insights", "sessions"]:
+        for table in ["sentences", "facts", "episodes", "sessions"]:
             async with self._conn.execute(
                 f"SELECT COUNT(*) FROM {table} WHERE user_id = ?", (user_id,)
             ) as cursor:

--- a/vektori/utils/async_worker.py
+++ b/vektori/utils/async_worker.py
@@ -1,4 +1,4 @@
-"""Token-threshold batched background worker for LLM fact + insight extraction."""
+"""Token-threshold batched background worker for LLM fact + episode extraction."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Closes #8

## Summary
- Renamed the L1 episodic memory layer from "insights" to "episodes" across all 30 files
- Pure terminology rename — zero functional changes
- Fixes internal inconsistency: the prompt already said "episodic memory records" but variables said "insights"

## What changed
- DB tables: `insights` → `episodes`, `insight_facts` → `episode_facts`
- Storage methods, config fields, search return keys, prompt name, all internal vars
- Examples, benchmarks, tests updated

## Migration
Existing DB users need to rename tables (see issue #8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation, examples, and guides to reflect the middle layer terminology change from "Insights" to "Episodes"

* **Refactor**
  * Renamed memory layer from "Insights" to "Episodes" throughout the system; API search results now return `episodes` instead of `insights` in the response structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->