### PR TITLE
feat(storage): add Neo4j and Qdrant storage backends

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,11 @@ name: Publish to PyPI
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -28,7 +31,19 @@ jobs:
       - name: Build package
         run: python -m build
 
+      - name: Check if version already on PyPI
+        id: version_check
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          VERSION=$(echo "$WHEEL" | sed 's/.*vektori-\(.*\)-py3.*/\1/')
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/vektori/${VERSION}/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already on PyPI, skipping upload."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to PyPI
+        if: steps.version_check.outputs.skip != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ EPISODE LAYER (L1)   <- patterns auto-discovered via graph traversal.
 SENTENCE LAYER (L2)  <- raw conversation. Sequential NEXT edges. The full story.
 ```
 
-Search hits Facts, graph discovers Episodes, traces back to source Sentences. One database, Postgres or SQLite. No Neo4j, no Qdrant, no infra drama.
+Search hits Facts, graph discovers Episodes, traces back to source Sentences. SQLite by default — swap to Postgres, Neo4j, or Qdrant when you're ready to scale.
 
 ---
 
@@ -42,7 +42,10 @@ Still improving. Run your own in [`/benchmarks`](benchmarks/).
 ## Install
 
 ```bash
-pip install vektori
+pip install vektori                      # SQLite + Postgres
+pip install 'vektori[neo4j]'             # + Neo4j support
+pip install 'vektori[qdrant]'            # + Qdrant support
+pip install 'vektori[neo4j,qdrant]'      # all backends
 ```
 
 No Docker, no external services. SQLite by default.
@@ -192,16 +195,53 @@ v = Vektori()
 # PostgreSQL + pgvector — production scale
 v = Vektori(database_url="postgresql://localhost:5432/vektori")
 
+# Neo4j — native graph traversal for Episode layer
+v = Vektori(
+    storage_backend="neo4j",
+    database_url="bolt://localhost:7687",
+    embedding_dimension=1024,   # must match your embedding model
+)
+
+# Qdrant — dedicated vector DB, cloud-ready
+v = Vektori(
+    storage_backend="qdrant",
+    database_url="http://localhost:6333",
+    embedding_dimension=1024,
+)
+
+# Qdrant Cloud
+v = Vektori(
+    storage_backend="qdrant",
+    database_url="https://your-cluster.qdrant.io",
+    qdrant_api_key="your-api-key",
+    embedding_dimension=1024,
+)
+
 # In-memory — tests / CI
 v = Vektori(storage_backend="memory")
 ```
 
-**Postgres via Docker:**
+**All backends via Docker:**
 ```bash
 git clone https://github.com/vektori-ai/vektori
 cd vektori
-docker compose up -d
+docker compose up -d                 # starts Postgres, Neo4j, and Qdrant
+
+# Postgres
 DATABASE_URL=postgresql://vektori:vektori@localhost:5432/vektori python examples/quickstart_postgres.py
+
+# Neo4j
+VEKTORI_STORAGE_BACKEND=neo4j VEKTORI_DATABASE_URL=bolt://localhost:7687 vektori add "I prefer dark mode" --user-id u1
+
+# Qdrant
+VEKTORI_STORAGE_BACKEND=qdrant VEKTORI_DATABASE_URL=http://localhost:6333 vektori add "I prefer dark mode" --user-id u1
+```
+
+**CLI storage flags:**
+```bash
+vektori config --storage-backend qdrant --database-url http://localhost:6333
+vektori add "my note" --user-id u1
+vektori search "preferences" --user-id u1
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,37 @@ services:
       timeout: 5s
       retries: 5
 
+  neo4j:
+    image: neo4j:5
+    environment:
+      NEO4J_AUTH: neo4j/password
+      NEO4J_PLUGINS: '["apoc"]'
+      NEO4J_dbms_security_procedures_unrestricted: apoc.*
+    ports:
+      - "7474:7474"   # HTTP browser
+      - "7687:7687"   # Bolt
+    volumes:
+      - neo4jdata:/data
+    healthcheck:
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "password", "RETURN 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"   # REST
+      - "6334:6334"   # gRPC
+    volumes:
+      - qdrantdata:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:6333/healthz || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
 volumes:
   pgdata:
+  neo4jdata:
+  qdrantdata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
 
 [project.optional-dependencies]
 postgres = ["asyncpg>=0.29", "pgvector>=0.2"]
+neo4j = ["neo4j>=5.14"]
+qdrant = ["qdrant-client>=1.7"]
 anthropic = ["anthropic>=0.20", "voyageai>=0.2"]
 sentence-transformers = ["sentence-transformers>=2.6"]
 bge = ["FlagEmbedding>=1.2"]
@@ -48,6 +50,8 @@ dev = [
 all = [
     "asyncpg>=0.29",
     "pgvector>=0.2",
+    "neo4j>=5.14",
+    "qdrant-client>=1.7",
     "anthropic>=0.20",
     "voyageai>=0.2",
     "sentence-transformers>=2.6",

--- a/tests/integration/test_neo4j_backend.py
+++ b/tests/integration/test_neo4j_backend.py
@@ -1,0 +1,312 @@
+"""Integration tests for Neo4jBackend — requires a live Neo4j instance.
+
+Start with:
+    docker run -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=neo4j/password neo4j:latest
+
+Tests are skipped automatically when the server is unreachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+NEO4J_URI = "bolt://localhost:7687"
+NEO4J_AUTH = ("neo4j", "password")
+
+
+def _is_neo4j_available() -> bool:
+    try:
+        import neo4j  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+async def _can_connect() -> bool:
+    if not _is_neo4j_available():
+        return False
+    try:
+        from neo4j import AsyncGraphDatabase
+
+        driver = AsyncGraphDatabase.driver(NEO4J_URI, auth=NEO4J_AUTH)
+        await driver.verify_connectivity()
+        await driver.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+async def neo4j_backend():
+    if not await _can_connect():
+        pytest.skip("Neo4j not reachable at bolt://localhost:7687")
+
+    from vektori.storage.neo4j_backend import Neo4jBackend
+
+    backend = Neo4jBackend(uri=NEO4J_URI, auth=NEO4J_AUTH, embedding_dim=4)
+    await backend.initialize()
+
+    # Wipe test data before each module run
+    await backend._q("MATCH (n) WHERE n.user_id = 'test-user' DETACH DELETE n")
+    yield backend
+    await backend._q("MATCH (n) WHERE n.user_id = 'test-user' DETACH DELETE n")
+    await backend.close()
+
+
+# ── Sentences ──────────────────────────────────────────────────────────────────
+
+
+async def test_upsert_and_search_sentences(neo4j_backend):
+    emb = [0.1, 0.2, 0.3, 0.4]
+    sentences = [
+        {
+            "id": "s1",
+            "text": "I love hiking in the mountains.",
+            "session_id": "sess1",
+            "turn_number": 0,
+            "sentence_index": 0,
+            "role": "user",
+        }
+    ]
+    count = await neo4j_backend.upsert_sentences(
+        sentences, [emb], user_id="test-user"
+    )
+    assert count == 1
+
+    results = await neo4j_backend.search_sentences(emb, user_id="test-user", limit=5)
+    assert len(results) >= 1
+    assert results[0]["text"] == "I love hiking in the mountains."
+    assert "distance" in results[0]
+
+
+async def test_sentence_dedup_increments_mentions(neo4j_backend):
+    emb = [0.1, 0.2, 0.3, 0.4]
+    sent = [
+        {
+            "id": "s-dedup",
+            "text": "Dedup test sentence.",
+            "session_id": "sess-dedup",
+            "turn_number": 0,
+            "sentence_index": 0,
+            "role": "user",
+        }
+    ]
+    await neo4j_backend.upsert_sentences(sent, [emb], user_id="test-user")
+    await neo4j_backend.upsert_sentences(sent, [emb], user_id="test-user")
+
+    results = await neo4j_backend.search_sentences(emb, user_id="test-user", limit=20)
+    matching = [r for r in results if r["text"] == "Dedup test sentence."]
+    assert len(matching) == 1
+    assert matching[0]["mentions"] == 2
+
+
+async def test_find_sentence_containing(neo4j_backend):
+    emb = [0.1, 0.2, 0.3, 0.4]
+    await neo4j_backend.upsert_sentences(
+        [
+            {
+                "id": "s-contain",
+                "text": "The quick brown fox jumps.",
+                "session_id": "sess-contain",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="test-user",
+    )
+    result = await neo4j_backend.find_sentence_containing("sess-contain", "quick brown")
+    assert result is not None
+    assert "quick brown" in result["text"].lower()
+
+    none_result = await neo4j_backend.find_sentence_containing("sess-contain", "xyz-missing")
+    assert none_result is None
+
+
+# ── Facts ─────────────────────────────────────────────────────────────────────
+
+
+async def test_insert_and_search_facts(neo4j_backend):
+    emb = [0.5, 0.5, 0.5, 0.5]
+    fid = await neo4j_backend.insert_fact(
+        text="User prefers dark mode.",
+        embedding=emb,
+        user_id="test-user",
+        subject="user",
+    )
+    assert fid
+
+    results = await neo4j_backend.search_facts(emb, user_id="test-user", limit=5)
+    assert any(r["id"] == fid for r in results)
+
+
+async def test_deactivate_fact(neo4j_backend):
+    emb = [0.3, 0.3, 0.3, 0.3]
+    fid = await neo4j_backend.insert_fact(
+        text="Fact to be deactivated.", embedding=emb, user_id="test-user"
+    )
+    await neo4j_backend.deactivate_fact(fid)
+
+    results = await neo4j_backend.search_facts(emb, user_id="test-user", active_only=True, limit=20)
+    assert all(r["id"] != fid for r in results)
+
+
+async def test_supersession_chain(neo4j_backend):
+    emb = [0.2, 0.2, 0.2, 0.2]
+    f1 = await neo4j_backend.insert_fact(
+        text="User is 25 years old.", embedding=emb, user_id="test-user"
+    )
+    f2 = await neo4j_backend.insert_fact(
+        text="User is 26 years old.", embedding=emb, user_id="test-user",
+        superseded_by_target=f1,
+    )
+    chain = await neo4j_backend.get_supersession_chain(f2)
+    ids = [r["id"] for r in chain]
+    assert f2 in ids
+    assert f1 in ids
+
+
+async def test_increment_fact_mentions(neo4j_backend):
+    emb = [0.9, 0.1, 0.1, 0.1]
+    fid = await neo4j_backend.insert_fact(
+        text="Mentions test fact.", embedding=emb, user_id="test-user"
+    )
+    await neo4j_backend.increment_fact_mentions(fid)
+    await neo4j_backend.increment_fact_mentions(fid)
+
+    results = await neo4j_backend.get_active_facts("test-user", limit=50)
+    matching = [r for r in results if r["id"] == fid]
+    # mentions not returned by get_active_facts — just verify no errors
+    assert len(matching) == 1
+
+
+# ── Join tables ───────────────────────────────────────────────────────────────
+
+
+async def test_fact_source_linking(neo4j_backend):
+    emb = [0.4, 0.4, 0.4, 0.4]
+    await neo4j_backend.upsert_sentences(
+        [
+            {
+                "id": "s-src1",
+                "text": "Source sentence for fact.",
+                "session_id": "sess-src",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="test-user",
+    )
+    fid = await neo4j_backend.insert_fact(
+        text="Fact derived from source.", embedding=emb, user_id="test-user"
+    )
+    await neo4j_backend.insert_fact_source(fid, "s-src1")
+
+    source_ids = await neo4j_backend.get_source_sentences([fid])
+    assert "s-src1" in source_ids
+
+
+# ── Expand session context ────────────────────────────────────────────────────
+
+
+async def test_expand_session_context(neo4j_backend):
+    emb = [0.1, 0.1, 0.1, 0.1]
+    sents = [
+        {
+            "id": f"ctx-{i}",
+            "text": f"Sentence {i}",
+            "session_id": "sess-ctx",
+            "turn_number": 0,
+            "sentence_index": i,
+            "role": "user",
+        }
+        for i in range(6)
+    ]
+    await neo4j_backend.upsert_sentences(sents, [emb] * 6, user_id="test-user")
+
+    expanded = await neo4j_backend.expand_session_context(["ctx-2"], window=1)
+    indices = [r["sentence_index"] for r in expanded]
+    assert 1 in indices and 2 in indices and 3 in indices
+
+
+# ── Sessions ──────────────────────────────────────────────────────────────────
+
+
+async def test_upsert_and_get_session(neo4j_backend):
+    await neo4j_backend.upsert_session(
+        session_id="sess-get", user_id="test-user", metadata={"source": "test"}
+    )
+    session = await neo4j_backend.get_session("sess-get", "test-user")
+    assert session is not None
+    assert session["id"] == "sess-get"
+    assert "sentences" in session
+
+
+async def test_count_sessions(neo4j_backend):
+    await neo4j_backend.upsert_session("sess-cnt-1", "test-user")
+    await neo4j_backend.upsert_session("sess-cnt-2", "test-user")
+    count = await neo4j_backend.count_sessions("test-user")
+    assert count >= 2
+
+
+# ── Episodes ──────────────────────────────────────────────────────────────────
+
+
+async def test_insert_and_search_episodes(neo4j_backend):
+    emb = [0.6, 0.6, 0.6, 0.6]
+    eid = await neo4j_backend.insert_episode(
+        text="User enjoys outdoor activities.",
+        embedding=emb,
+        user_id="test-user",
+    )
+    assert eid
+
+    results = await neo4j_backend.search_episodes(emb, user_id="test-user", limit=5)
+    assert any(r["id"] == eid for r in results)
+
+
+async def test_episodes_for_facts(neo4j_backend):
+    emb = [0.7, 0.7, 0.7, 0.7]
+    fid = await neo4j_backend.insert_fact(
+        text="Episode linkage fact.", embedding=emb, user_id="test-user"
+    )
+    eid = await neo4j_backend.insert_episode(
+        text="Episode linked to fact.", embedding=emb, user_id="test-user"
+    )
+    await neo4j_backend.insert_episode_fact(eid, fid)
+
+    episodes = await neo4j_backend.get_episodes_for_facts([fid])
+    assert any(e["id"] == eid for e in episodes)
+
+
+# ── GDPR ──────────────────────────────────────────────────────────────────────
+
+
+async def test_delete_user(neo4j_backend):
+    emb = [0.8, 0.8, 0.8, 0.8]
+    await neo4j_backend.upsert_sentences(
+        [
+            {
+                "id": "del-s1",
+                "text": "To be deleted.",
+                "session_id": "del-sess",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="delete-test-user",
+    )
+    await neo4j_backend.insert_fact(
+        text="Fact to delete.", embedding=emb, user_id="delete-test-user"
+    )
+    deleted = await neo4j_backend.delete_user("delete-test-user")
+    assert deleted >= 2
+
+    remaining = await neo4j_backend.search_sentences(emb, user_id="delete-test-user")
+    assert remaining == []

--- a/tests/integration/test_neo4j_backend.py
+++ b/tests/integration/test_neo4j_backend.py
@@ -69,9 +69,7 @@ async def test_upsert_and_search_sentences(neo4j_backend):
             "role": "user",
         }
     ]
-    count = await neo4j_backend.upsert_sentences(
-        sentences, [emb], user_id="test-user"
-    )
+    count = await neo4j_backend.upsert_sentences(sentences, [emb], user_id="test-user")
     assert count == 1
 
     results = await neo4j_backend.search_sentences(emb, user_id="test-user", limit=5)
@@ -159,7 +157,9 @@ async def test_supersession_chain(neo4j_backend):
         text="User is 25 years old.", embedding=emb, user_id="test-user"
     )
     f2 = await neo4j_backend.insert_fact(
-        text="User is 26 years old.", embedding=emb, user_id="test-user",
+        text="User is 26 years old.",
+        embedding=emb,
+        user_id="test-user",
         superseded_by_target=f1,
     )
     chain = await neo4j_backend.get_supersession_chain(f2)

--- a/tests/integration/test_qdrant_backend.py
+++ b/tests/integration/test_qdrant_backend.py
@@ -1,0 +1,402 @@
+"""Integration tests for QdrantBackend — requires a live Qdrant instance.
+
+Start with:
+    docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
+
+Tests are skipped automatically when the server is unreachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+QDRANT_URL = "http://localhost:6333"
+TEST_PREFIX = "vektori_test"
+
+
+def _is_qdrant_available() -> bool:
+    try:
+        import qdrant_client  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+async def _can_connect() -> bool:
+    if not _is_qdrant_available():
+        return False
+    try:
+        from qdrant_client import AsyncQdrantClient
+
+        client = AsyncQdrantClient(url=QDRANT_URL)
+        await client.get_collections()
+        await client.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+async def qdrant_backend():
+    if not await _can_connect():
+        pytest.skip("Qdrant not reachable at http://localhost:6333")
+
+    from vektori.storage.qdrant_backend import QdrantBackend
+
+    backend = QdrantBackend(url=QDRANT_URL, prefix=TEST_PREFIX, embedding_dim=4)
+    await backend.initialize()
+    yield backend
+    # Teardown: delete all test user data
+    await backend.delete_user("test-user")
+    await backend.delete_user("delete-test-user")
+    await backend.close()
+
+
+# ── Sentences ──────────────────────────────────────────────────────────────────
+
+
+async def test_upsert_and_search_sentences(qdrant_backend):
+    emb = [0.1, 0.2, 0.3, 0.4]
+    sentences = [
+        {
+            "id": "qs1",
+            "text": "I love hiking in the mountains.",
+            "session_id": "qsess1",
+            "turn_number": 0,
+            "sentence_index": 0,
+            "role": "user",
+        }
+    ]
+    count = await qdrant_backend.upsert_sentences(sentences, [emb], user_id="test-user")
+    assert count == 1
+
+    results = await qdrant_backend.search_sentences(emb, user_id="test-user", limit=5)
+    assert len(results) >= 1
+    assert results[0]["text"] == "I love hiking in the mountains."
+    assert "distance" in results[0]
+
+
+async def test_sentence_dedup_increments_mentions(qdrant_backend):
+    emb = [0.1, 0.2, 0.3, 0.4]
+    sent = [
+        {
+            "id": "qs-dedup",
+            "text": "Qdrant dedup test sentence.",
+            "session_id": "qsess-dedup",
+            "turn_number": 0,
+            "sentence_index": 0,
+            "role": "user",
+        }
+    ]
+    await qdrant_backend.upsert_sentences(sent, [emb], user_id="test-user")
+    await qdrant_backend.upsert_sentences(sent, [emb], user_id="test-user")
+
+    results = await qdrant_backend.search_sentences(emb, user_id="test-user", limit=20)
+    matching = [r for r in results if r["text"] == "Qdrant dedup test sentence."]
+    assert len(matching) == 1
+    assert matching[0]["mentions"] == 2
+
+
+async def test_find_sentence_containing(qdrant_backend):
+    emb = [0.1, 0.2, 0.3, 0.4]
+    await qdrant_backend.upsert_sentences(
+        [
+            {
+                "id": "qs-contain",
+                "text": "The quick brown fox jumps over.",
+                "session_id": "qsess-contain",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="test-user",
+    )
+    result = await qdrant_backend.find_sentence_containing("qsess-contain", "quick brown")
+    assert result is not None
+    assert "quick brown" in result["text"].lower()
+
+    none_result = await qdrant_backend.find_sentence_containing("qsess-contain", "xyz-missing")
+    assert none_result is None
+
+
+async def test_search_sentences_in_session(qdrant_backend):
+    emb = [0.9, 0.1, 0.1, 0.1]
+    await qdrant_backend.upsert_sentences(
+        [
+            {
+                "id": "qs-sess-search",
+                "text": "Session-scoped search test.",
+                "session_id": "qsess-scoped",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="test-user",
+    )
+    ids = await qdrant_backend.search_sentences_in_session(
+        emb, session_id="qsess-scoped", threshold=0.5
+    )
+    assert "qs-sess-search" in ids
+
+
+# ── Facts ─────────────────────────────────────────────────────────────────────
+
+
+async def test_insert_and_search_facts(qdrant_backend):
+    emb = [0.5, 0.5, 0.5, 0.5]
+    fid = await qdrant_backend.insert_fact(
+        text="User prefers dark mode.",
+        embedding=emb,
+        user_id="test-user",
+        subject="user",
+    )
+    assert fid
+
+    results = await qdrant_backend.search_facts(emb, user_id="test-user", limit=5)
+    assert any(r["id"] == fid for r in results)
+    hit = next(r for r in results if r["id"] == fid)
+    assert hit["subject"] == "user"
+
+
+async def test_deactivate_fact(qdrant_backend):
+    emb = [0.3, 0.3, 0.3, 0.3]
+    fid = await qdrant_backend.insert_fact(
+        text="Qdrant fact to deactivate.", embedding=emb, user_id="test-user"
+    )
+    await qdrant_backend.deactivate_fact(fid)
+
+    results = await qdrant_backend.search_facts(
+        emb, user_id="test-user", active_only=True, limit=20
+    )
+    assert all(r["id"] != fid for r in results)
+
+
+async def test_supersession_chain(qdrant_backend):
+    emb = [0.2, 0.2, 0.2, 0.2]
+    f1 = await qdrant_backend.insert_fact(
+        text="User is 25 years old.", embedding=emb, user_id="test-user"
+    )
+    f2 = await qdrant_backend.insert_fact(
+        text="User is 26 years old.", embedding=emb, user_id="test-user",
+        superseded_by_target=f1,
+    )
+    chain = await qdrant_backend.get_supersession_chain(f2)
+    ids = [r["id"] for r in chain]
+    assert f2 in ids
+    assert f1 in ids
+
+
+async def test_increment_fact_mentions(qdrant_backend):
+    emb = [0.9, 0.1, 0.1, 0.1]
+    fid = await qdrant_backend.insert_fact(
+        text="Qdrant mentions test.", embedding=emb, user_id="test-user"
+    )
+    await qdrant_backend.increment_fact_mentions(fid)
+    await qdrant_backend.increment_fact_mentions(fid)
+
+    points = await qdrant_backend._client.retrieve(
+        collection_name=qdrant_backend._facts_col,
+        ids=[fid],
+        with_payload=["mentions"],
+    )
+    assert points[0].payload["mentions"] == 3
+
+
+async def test_get_active_facts(qdrant_backend):
+    emb = [0.4, 0.4, 0.4, 0.4]
+    fid = await qdrant_backend.insert_fact(
+        text="Active fact check.", embedding=emb, user_id="test-user"
+    )
+    facts = await qdrant_backend.get_active_facts("test-user", limit=50)
+    assert any(f["id"] == fid for f in facts)
+
+
+# ── Join tables ───────────────────────────────────────────────────────────────
+
+
+async def test_fact_source_linking(qdrant_backend):
+    emb = [0.4, 0.4, 0.4, 0.4]
+    await qdrant_backend.upsert_sentences(
+        [
+            {
+                "id": "qs-src1",
+                "text": "Qdrant source sentence.",
+                "session_id": "qsess-src",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="test-user",
+    )
+    fid = await qdrant_backend.insert_fact(
+        text="Fact derived from Qdrant source.", embedding=emb, user_id="test-user"
+    )
+    await qdrant_backend.insert_fact_source(fid, "qs-src1")
+
+    source_ids = await qdrant_backend.get_source_sentences([fid])
+    assert "qs-src1" in source_ids
+
+
+async def test_batch_fact_sources(qdrant_backend):
+    emb = [0.4, 0.4, 0.4, 0.4]
+    await qdrant_backend.upsert_sentences(
+        [
+            {"id": f"qs-batch-s{i}", "text": f"Batch source {i}.",
+             "session_id": "qsess-batch", "turn_number": 0, "sentence_index": i, "role": "user"}
+            for i in range(3)
+        ],
+        [emb] * 3,
+        user_id="test-user",
+    )
+    fid = await qdrant_backend.insert_fact(
+        text="Batch fact.", embedding=emb, user_id="test-user"
+    )
+    await qdrant_backend.insert_fact_sources(
+        [(fid, "qs-batch-s0"), (fid, "qs-batch-s1"), (fid, "qs-batch-s2")]
+    )
+    source_ids = await qdrant_backend.get_source_sentences([fid])
+    assert set(source_ids) >= {"qs-batch-s0", "qs-batch-s1", "qs-batch-s2"}
+
+
+# ── Expand session context ────────────────────────────────────────────────────
+
+
+async def test_expand_session_context(qdrant_backend):
+    emb = [0.1, 0.1, 0.1, 0.1]
+    sents = [
+        {
+            "id": f"qctx-{i}",
+            "text": f"Qdrant context sentence {i}",
+            "session_id": "qsess-ctx",
+            "turn_number": 0,
+            "sentence_index": i,
+            "role": "user",
+        }
+        for i in range(6)
+    ]
+    await qdrant_backend.upsert_sentences(sents, [emb] * 6, user_id="test-user")
+
+    expanded = await qdrant_backend.expand_session_context(["qctx-2"], window=1)
+    indices = [r["sentence_index"] for r in expanded]
+    assert 1 in indices and 2 in indices and 3 in indices
+
+
+async def test_get_sentences_by_ids(qdrant_backend):
+    emb = [0.1, 0.1, 0.1, 0.1]
+    await qdrant_backend.upsert_sentences(
+        [
+            {
+                "id": "qs-byid1",
+                "text": "Fetch by id test.",
+                "session_id": "qsess-byid",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="test-user",
+    )
+    rows = await qdrant_backend.get_sentences_by_ids(["qs-byid1"])
+    assert len(rows) == 1
+    assert rows[0]["text"] == "Fetch by id test."
+
+
+# ── Sessions ──────────────────────────────────────────────────────────────────
+
+
+async def test_upsert_and_get_session(qdrant_backend):
+    await qdrant_backend.upsert_session(
+        session_id="qsess-get", user_id="test-user", metadata={"src": "test"}
+    )
+    session = await qdrant_backend.get_session("qsess-get", "test-user")
+    assert session is not None
+    assert session["id"] == "qsess-get"
+    assert "sentences" in session
+
+
+async def test_count_sessions(qdrant_backend):
+    await qdrant_backend.upsert_session("qsess-cnt1", "test-user")
+    await qdrant_backend.upsert_session("qsess-cnt2", "test-user")
+    count = await qdrant_backend.count_sessions("test-user")
+    assert count >= 2
+
+
+async def test_get_session_wrong_user_returns_none(qdrant_backend):
+    await qdrant_backend.upsert_session("qsess-private", "test-user")
+    result = await qdrant_backend.get_session("qsess-private", "other-user")
+    assert result is None
+
+
+# ── Episodes ──────────────────────────────────────────────────────────────────
+
+
+async def test_insert_and_search_episodes(qdrant_backend):
+    emb = [0.6, 0.6, 0.6, 0.6]
+    eid = await qdrant_backend.insert_episode(
+        text="User enjoys outdoor activities in Qdrant.",
+        embedding=emb,
+        user_id="test-user",
+    )
+    assert eid
+
+    results = await qdrant_backend.search_episodes(emb, user_id="test-user", limit=5)
+    assert any(r["id"] == eid for r in results)
+
+
+async def test_episode_idempotent(qdrant_backend):
+    emb = [0.6, 0.6, 0.6, 0.6]
+    text = "Idempotent episode insert."
+    eid1 = await qdrant_backend.insert_episode(text, emb, user_id="test-user")
+    eid2 = await qdrant_backend.insert_episode(text, emb, user_id="test-user")
+    assert eid1 == eid2
+
+
+async def test_episodes_for_facts(qdrant_backend):
+    emb = [0.7, 0.7, 0.7, 0.7]
+    fid = await qdrant_backend.insert_fact(
+        text="Qdrant episode linkage fact.", embedding=emb, user_id="test-user"
+    )
+    eid = await qdrant_backend.insert_episode(
+        text="Qdrant episode linked to fact.", embedding=emb, user_id="test-user"
+    )
+    await qdrant_backend.insert_episode_fact(eid, fid)
+
+    episodes = await qdrant_backend.get_episodes_for_facts([fid])
+    assert any(e["id"] == eid for e in episodes)
+
+
+# ── GDPR ──────────────────────────────────────────────────────────────────────
+
+
+async def test_delete_user(qdrant_backend):
+    emb = [0.8, 0.8, 0.8, 0.8]
+    await qdrant_backend.upsert_sentences(
+        [
+            {
+                "id": "qdel-s1",
+                "text": "Qdrant delete user sentence.",
+                "session_id": "qdel-sess",
+                "turn_number": 0,
+                "sentence_index": 0,
+                "role": "user",
+            }
+        ],
+        [emb],
+        user_id="delete-test-user",
+    )
+    await qdrant_backend.insert_fact(
+        text="Qdrant delete user fact.", embedding=emb, user_id="delete-test-user"
+    )
+    deleted = await qdrant_backend.delete_user("delete-test-user")
+    assert deleted >= 2
+
+    remaining = await qdrant_backend.search_sentences(emb, user_id="delete-test-user")
+    assert remaining == []

--- a/tests/integration/test_qdrant_backend.py
+++ b/tests/integration/test_qdrant_backend.py
@@ -182,7 +182,9 @@ async def test_supersession_chain(qdrant_backend):
         text="User is 25 years old.", embedding=emb, user_id="test-user"
     )
     f2 = await qdrant_backend.insert_fact(
-        text="User is 26 years old.", embedding=emb, user_id="test-user",
+        text="User is 26 years old.",
+        embedding=emb,
+        user_id="test-user",
         superseded_by_target=f1,
     )
     chain = await qdrant_backend.get_supersession_chain(f2)
@@ -248,16 +250,20 @@ async def test_batch_fact_sources(qdrant_backend):
     emb = [0.4, 0.4, 0.4, 0.4]
     await qdrant_backend.upsert_sentences(
         [
-            {"id": f"qs-batch-s{i}", "text": f"Batch source {i}.",
-             "session_id": "qsess-batch", "turn_number": 0, "sentence_index": i, "role": "user"}
+            {
+                "id": f"qs-batch-s{i}",
+                "text": f"Batch source {i}.",
+                "session_id": "qsess-batch",
+                "turn_number": 0,
+                "sentence_index": i,
+                "role": "user",
+            }
             for i in range(3)
         ],
         [emb] * 3,
         user_id="test-user",
     )
-    fid = await qdrant_backend.insert_fact(
-        text="Batch fact.", embedding=emb, user_id="test-user"
-    )
+    fid = await qdrant_backend.insert_fact(text="Batch fact.", embedding=emb, user_id="test-user")
     await qdrant_backend.insert_fact_sources(
         [(fid, "qs-batch-s0"), (fid, "qs-batch-s1"), (fid, "qs-batch-s2")]
     )

--- a/tests/unit/test_new_backends_factory.py
+++ b/tests/unit/test_new_backends_factory.py
@@ -11,7 +11,6 @@ from vektori.storage.factory import create_storage
 from vektori.storage.neo4j_backend import Neo4jBackend
 from vektori.storage.qdrant_backend import QdrantBackend
 
-
 # ── Factory routing: storage_backend key ──────────────────────────────────────
 
 

--- a/tests/unit/test_new_backends_factory.py
+++ b/tests/unit/test_new_backends_factory.py
@@ -1,0 +1,130 @@
+"""Unit tests for Neo4j and Qdrant factory routing — no live server required."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from vektori.config import VektoriConfig
+from vektori.storage.factory import create_storage
+from vektori.storage.neo4j_backend import Neo4jBackend
+from vektori.storage.qdrant_backend import QdrantBackend
+
+
+# ── Factory routing: storage_backend key ──────────────────────────────────────
+
+
+async def test_factory_neo4j_by_key():
+    cfg = VektoriConfig(storage_backend="neo4j", embedding_dimension=1024)
+    with patch.object(Neo4jBackend, "initialize", new_callable=AsyncMock):
+        backend = await create_storage(cfg)
+    assert isinstance(backend, Neo4jBackend)
+    assert backend.embedding_dim == 1024
+
+
+async def test_factory_qdrant_by_key():
+    cfg = VektoriConfig(storage_backend="qdrant", embedding_dimension=768)
+    with patch.object(QdrantBackend, "initialize", new_callable=AsyncMock):
+        backend = await create_storage(cfg)
+    assert isinstance(backend, QdrantBackend)
+    assert backend.embedding_dim == 768
+
+
+# ── Factory routing: URL-based heuristic ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "bolt://localhost:7687",
+        "neo4j://localhost:7687",
+        "neo4j+s://myhost:7687",
+    ],
+)
+async def test_factory_neo4j_by_url(url):
+    cfg = VektoriConfig(storage_backend="sqlite", database_url=url)
+    with patch.object(Neo4jBackend, "initialize", new_callable=AsyncMock):
+        backend = await create_storage(cfg)
+    assert isinstance(backend, Neo4jBackend)
+    assert backend.uri == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:6333",
+        "http://qdrant-host:6333",
+    ],
+)
+async def test_factory_qdrant_by_url(url):
+    cfg = VektoriConfig(storage_backend="sqlite", database_url=url)
+    with patch.object(QdrantBackend, "initialize", new_callable=AsyncMock):
+        backend = await create_storage(cfg)
+    assert isinstance(backend, QdrantBackend)
+    assert backend.url == url
+
+
+# ── Neo4j auth parsing in factory ─────────────────────────────────────────────
+
+
+async def test_factory_neo4j_auth_from_url():
+    """bolt://... user:pass format parsed correctly."""
+    cfg = VektoriConfig(
+        storage_backend="neo4j",
+        database_url="bolt://prod-host:7687 admin:s3cr3t",
+    )
+    with patch.object(Neo4jBackend, "initialize", new_callable=AsyncMock):
+        backend = await create_storage(cfg)
+    assert isinstance(backend, Neo4jBackend)
+    assert backend.uri == "bolt://prod-host:7687"
+    assert backend.auth == ("admin", "s3cr3t")
+
+
+async def test_factory_neo4j_default_auth():
+    """Default auth (neo4j / password) used when no creds in URL."""
+    cfg = VektoriConfig(storage_backend="neo4j", database_url="bolt://localhost:7687")
+    with patch.object(Neo4jBackend, "initialize", new_callable=AsyncMock):
+        backend = await create_storage(cfg)
+    assert backend.auth == ("neo4j", "password")
+
+
+# ── QdrantBackend constructor defaults ────────────────────────────────────────
+
+
+def test_qdrant_default_url():
+    b = QdrantBackend()
+    assert b.url == "http://localhost:6333"
+    assert b.prefix == "vektori"
+    assert b.embedding_dim == 1024
+
+
+def test_qdrant_custom_prefix():
+    b = QdrantBackend(url="http://host:6333", prefix="myapp", embedding_dim=512)
+    assert b.prefix == "myapp"
+    assert b._facts_col == "myapp_facts"
+    assert b._sentences_col == "myapp_sentences"
+    assert b._episodes_col == "myapp_episodes"
+    assert b._sessions_col == "myapp_sessions"
+
+
+# ── Neo4jBackend constructor defaults ─────────────────────────────────────────
+
+
+def test_neo4j_defaults():
+    b = Neo4jBackend(uri="bolt://localhost:7687")
+    assert b.auth == ("neo4j", "password")
+    assert b.database == "neo4j"
+    assert b.embedding_dim == 1024
+    assert b._driver is None
+
+
+def test_neo4j_custom_params():
+    b = Neo4jBackend(
+        uri="neo4j+s://prod:7687",
+        auth=("alice", "pw"),
+        database="mydb",
+        embedding_dim=768,
+    )
+    assert b.database == "mydb"
+    assert b.embedding_dim == 768

--- a/vektori/cli.py
+++ b/vektori/cli.py
@@ -25,6 +25,18 @@ _EMBEDDING_HELP = (
     "Embedding model. e.g. 'sentence-transformers:all-MiniLM-L6-v2' (local), "
     "'openai:text-embedding-3-small' [env: VEKTORI_EMBEDDING_MODEL]"
 )
+_BACKEND_HELP = (
+    "Storage backend: sqlite (default), postgres, memory, neo4j, qdrant. "
+    "[env: VEKTORI_STORAGE_BACKEND]"
+)
+_DATABASE_URL_HELP = (
+    "Connection URL for the backend. "
+    "Postgres: postgresql://user:pw@host/db  "
+    "Neo4j: bolt://host:7687  "
+    "Qdrant: http://host:6333  "
+    "[env: VEKTORI_DATABASE_URL]"
+)
+_QDRANT_API_KEY_HELP = "Qdrant Cloud API key. [env: QDRANT_API_KEY]"
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +105,24 @@ def _silence_litellm() -> None:
         pass
 
 
-def _client(extraction_model: str, embedding_model: str, sync_extraction: bool = True):
+def _default_storage_backend() -> str:
+    cfg = _load_config()
+    return os.environ.get("VEKTORI_STORAGE_BACKEND") or cfg.get("storage_backend") or "sqlite"
+
+
+def _default_database_url() -> str | None:
+    cfg = _load_config()
+    return os.environ.get("VEKTORI_DATABASE_URL") or cfg.get("database_url")
+
+
+def _client(
+    extraction_model: str,
+    embedding_model: str,
+    sync_extraction: bool = True,
+    storage_backend: str | None = None,
+    database_url: str | None = None,
+    qdrant_api_key: str | None = None,
+):
     from vektori.client import Vektori
     from vektori.config import VektoriConfig
 
@@ -103,6 +132,9 @@ def _client(extraction_model: str, embedding_model: str, sync_extraction: bool =
         embedding_model=embedding_model,
         async_extraction=not sync_extraction,
         enable_retrieval_gate=False,
+        storage_backend=storage_backend or _default_storage_backend(),
+        database_url=database_url or _default_database_url(),
+        qdrant_api_key=qdrant_api_key or os.environ.get("QDRANT_API_KEY"),
     )
     return Vektori(config=cfg)
 
@@ -125,15 +157,19 @@ def config(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(None, "--storage-backend", help=_BACKEND_HELP),
+    database_url: str | None = typer.Option(None, "--database-url", help=_DATABASE_URL_HELP),
     show: bool = typer.Option(False, "--show", help="Print current config."),
     reset: bool = typer.Option(False, "--reset", help="Reset to defaults."),
 ) -> None:
-    """Set default models so you don't have to pass --extraction-model / --embedding-model every time.
+    """Set default models and storage so you don't have to pass flags every time.
 
     \b
     Examples:
       vektori config --extraction-model "litellm:groq/llama-3.3-70b-versatile"
       vektori config --embedding-model "sentence-transformers:all-MiniLM-L6-v2"
+      vektori config --storage-backend qdrant --database-url http://localhost:6333
+      vektori config --storage-backend neo4j --database-url "bolt://localhost:7687"
       vektori config --show
     """
     if reset:
@@ -148,15 +184,23 @@ def config(
         cfg["extraction_model"] = extraction_model
     if embedding_model:
         cfg["embedding_model"] = embedding_model
+    if storage_backend:
+        cfg["storage_backend"] = storage_backend
+    if database_url:
+        cfg["database_url"] = database_url
 
-    if extraction_model or embedding_model:
+    if extraction_model or embedding_model or storage_backend or database_url:
         _save_config(cfg)
         typer.echo(f"Saved to {_CONFIG_PATH}")
 
-    if show or not (extraction_model or embedding_model or reset):
-        typer.echo(f"Config file : {_CONFIG_PATH}")
-        typer.echo(f"extraction  : {_default_extraction()}")
-        typer.echo(f"embedding   : {_default_embedding()}")
+    if show or not (
+        extraction_model or embedding_model or storage_backend or database_url or reset
+    ):
+        typer.echo(f"Config file     : {_CONFIG_PATH}")
+        typer.echo(f"extraction      : {_default_extraction()}")
+        typer.echo(f"embedding       : {_default_embedding()}")
+        typer.echo(f"storage_backend : {_default_storage_backend()}")
+        typer.echo(f"database_url    : {_default_database_url() or '(default)'}")
 
 
 # ---------------------------------------------------------------------------
@@ -172,15 +216,30 @@ def init(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", envvar="VEKTORI_EMBEDDING_MODEL", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
 ) -> None:
-    """Initialise local SQLite storage."""
+    """Initialise storage backend (SQLite by default)."""
     em = extraction_model or _default_extraction()
     eb = embedding_model or _default_embedding()
     _warn_openai(em, "--extraction-model")
     _warn_openai(eb, "--embedding-model")
 
     async def _run() -> None:
-        v = _client(em, eb)
+        v = _client(
+            em,
+            eb,
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         await v._ensure_initialized()
         await v.close()
 
@@ -206,6 +265,15 @@ def add(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", envvar="VEKTORI_EMBEDDING_MODEL", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     no_extraction: bool = typer.Option(
         False,
         "--no-extraction",
@@ -223,7 +291,14 @@ def add(
     messages = [{"role": "user", "content": text}]
 
     async def _run() -> dict:
-        v = _client(em, eb, sync_extraction=not no_extraction)
+        v = _client(
+            em,
+            eb,
+            sync_extraction=not no_extraction,
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         try:
             result = await v.add(messages, session_id=sid, user_id=user_id)
         finally:
@@ -261,6 +336,15 @@ def search(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", envvar="VEKTORI_EMBEDDING_MODEL", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     expand: bool = typer.Option(
         False, "--expand", help="Use LLM to generate query variants before searching."
     ),
@@ -272,7 +356,13 @@ def search(
     _warn_openai(eb, "--embedding-model")
 
     async def _run() -> dict:
-        v = _client(em, eb)
+        v = _client(
+            em,
+            eb,
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         try:
             result = await v.search(query, user_id=user_id, top_k=top_k, depth=depth, expand=expand)
         finally:
@@ -320,13 +410,28 @@ def list_memories(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", envvar="VEKTORI_EMBEDDING_MODEL", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """List all active memories (extracted facts) for a user."""
     eb = embedding_model or _default_embedding()
 
     async def _run() -> list:
-        v = _client(_default_extraction(), eb)
+        v = _client(
+            _default_extraction(),
+            eb,
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         try:
             facts = await v.get_facts(user_id=user_id)
         finally:
@@ -356,6 +461,15 @@ def list_memories(
 def delete(
     user_id: str = typer.Option(..., "--user-id", "-u", envvar="VEKTORI_USER_ID", help="User ID."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Delete all memories for a user."""
@@ -363,7 +477,13 @@ def delete(
         typer.confirm(f"Delete ALL memories for user '{user_id}'?", abort=True)
 
     async def _run() -> int:
-        v = _client(_default_extraction(), _default_embedding())
+        v = _client(
+            _default_extraction(),
+            _default_embedding(),
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         try:
             n = await v.delete_user(user_id=user_id)
         finally:
@@ -395,6 +515,15 @@ def remember(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", envvar="VEKTORI_EMBEDDING_MODEL", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Remember something. Alias for `add` — reads naturally in agent prompts."""
@@ -405,7 +534,13 @@ def remember(
     messages = [{"role": "user", "content": text}]
 
     async def _run() -> dict:
-        v = _client(em, eb)
+        v = _client(
+            em,
+            eb,
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         try:
             result = await v.add(messages, session_id=sid, user_id=user_id)
         finally:
@@ -442,6 +577,15 @@ def recall(
     embedding_model: str | None = typer.Option(
         None, "--embedding-model", "-e", envvar="VEKTORI_EMBEDDING_MODEL", help=_EMBEDDING_HELP
     ),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Recall memories. Alias for `search` — reads naturally in agent prompts."""
@@ -449,7 +593,13 @@ def recall(
     eb = embedding_model or _default_embedding()
 
     async def _run() -> dict:
-        v = _client(em, eb)
+        v = _client(
+            em,
+            eb,
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         try:
             result = await v.search(query, user_id=user_id, top_k=top_k, depth="l1")
         finally:
@@ -502,12 +652,27 @@ def recall(
 @app.command()
 def stats(
     user_id: str = typer.Option(..., "--user-id", "-u", envvar="VEKTORI_USER_ID", help="User ID."),
+    storage_backend: str | None = typer.Option(
+        None, "--storage-backend", envvar="VEKTORI_STORAGE_BACKEND", help=_BACKEND_HELP
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="VEKTORI_DATABASE_URL", help=_DATABASE_URL_HELP
+    ),
+    qdrant_api_key: str | None = typer.Option(
+        None, "--qdrant-api-key", envvar="QDRANT_API_KEY", help=_QDRANT_API_KEY_HELP
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Show memory stats for a user."""
 
     async def _run() -> dict:
-        v = _client(_default_extraction(), _default_embedding())
+        v = _client(
+            _default_extraction(),
+            _default_embedding(),
+            storage_backend=storage_backend,
+            database_url=database_url,
+            qdrant_api_key=qdrant_api_key,
+        )
         await v._ensure_initialized()
         try:
             facts = await v.get_facts(user_id=user_id)

--- a/vektori/client.py
+++ b/vektori/client.py
@@ -39,6 +39,7 @@ class Vektori:
         context_window: int = 3,
         temporal_decay_rate: float = 0.001,
         async_extraction: bool = True,
+        qdrant_api_key: str | None = None,
         config: VektoriConfig | None = None,
     ) -> None:
         if config is not None:
@@ -56,6 +57,7 @@ class Vektori:
                 context_window=context_window,
                 temporal_decay_rate=temporal_decay_rate,
                 async_extraction=async_extraction,
+                qdrant_api_key=qdrant_api_key,
             )
 
         self._initialized = False

--- a/vektori/config.py
+++ b/vektori/config.py
@@ -22,7 +22,8 @@ class VektoriConfig:
 
     # Storage
     database_url: str | None = None  # None = SQLite default (~/.vektori/vektori.db)
-    storage_backend: str = "sqlite"  # "sqlite", "postgres", "memory"
+    storage_backend: str = "sqlite"  # "sqlite", "postgres", "memory", "neo4j", "qdrant"
+    qdrant_api_key: str | None = None  # Qdrant Cloud API key (not needed for local)
 
     # Embedding provider — format: "provider:model_name"
     embedding_model: str = "openai:text-embedding-3-small"

--- a/vektori/storage/factory.py
+++ b/vektori/storage/factory.py
@@ -71,6 +71,7 @@ async def create_storage(config: VektoriConfig) -> StorageBackend:
         url = database_url or "http://localhost:6333"
         backend = QdrantBackend(
             url=url,
+            api_key=config.qdrant_api_key,
             embedding_dim=config.embedding_dimension,
         )
 

--- a/vektori/storage/factory.py
+++ b/vektori/storage/factory.py
@@ -7,7 +7,12 @@ from vektori.storage.base import StorageBackend
 
 
 async def create_storage(config: VektoriConfig) -> StorageBackend:
-    """Resolve and initialize the correct storage backend from config."""
+    """Resolve and initialize the correct storage backend from config.
+
+    Backend selection priority:
+        1. config.storage_backend key  ("sqlite", "postgres", "memory", "neo4j", "qdrant")
+        2. URL prefix heuristic        (postgresql://, bolt://, neo4j://, http://localhost:6333)
+    """
     backend_key = config.storage_backend
     database_url = config.database_url
 
@@ -16,7 +21,9 @@ async def create_storage(config: VektoriConfig) -> StorageBackend:
 
         backend: StorageBackend = MemoryBackend()
 
-    elif backend_key == "postgres" or (database_url and "postgresql" in database_url):
+    elif backend_key == "postgres" or (
+        database_url and "postgresql" in database_url
+    ):
         from vektori.storage.postgres import PostgresBackend
 
         if not database_url:
@@ -26,6 +33,44 @@ async def create_storage(config: VektoriConfig) -> StorageBackend:
             )
         backend = PostgresBackend(
             database_url,
+            embedding_dim=config.embedding_dimension,
+        )
+
+    elif backend_key == "neo4j" or (
+        database_url and (
+            database_url.startswith("bolt://")
+            or database_url.startswith("neo4j://")
+            or database_url.startswith("neo4j+s://")
+        )
+    ):
+        from vektori.storage.neo4j_backend import Neo4jBackend
+
+        uri = database_url or "bolt://localhost:7687"
+        # Auth can be passed as "user:password" appended after a space, e.g.:
+        #   database_url="bolt://localhost:7687 neo4j:password"
+        # or left as default ("neo4j", "password") for local dev.
+        user, password = "neo4j", "password"
+        if " " in uri:
+            uri, creds = uri.split(" ", 1)
+            if ":" in creds:
+                user, password = creds.split(":", 1)
+        backend = Neo4jBackend(
+            uri=uri,
+            auth=(user, password),
+            embedding_dim=config.embedding_dimension,
+        )
+
+    elif backend_key == "qdrant" or (
+        database_url and (
+            "qdrant" in database_url
+            or (database_url.startswith("http") and ":6333" in database_url)
+        )
+    ):
+        from vektori.storage.qdrant_backend import QdrantBackend
+
+        url = database_url or "http://localhost:6333"
+        backend = QdrantBackend(
+            url=url,
             embedding_dim=config.embedding_dimension,
         )
 

--- a/vektori/storage/factory.py
+++ b/vektori/storage/factory.py
@@ -21,9 +21,7 @@ async def create_storage(config: VektoriConfig) -> StorageBackend:
 
         backend: StorageBackend = MemoryBackend()
 
-    elif backend_key == "postgres" or (
-        database_url and "postgresql" in database_url
-    ):
+    elif backend_key == "postgres" or (database_url and "postgresql" in database_url):
         from vektori.storage.postgres import PostgresBackend
 
         if not database_url:
@@ -37,7 +35,8 @@ async def create_storage(config: VektoriConfig) -> StorageBackend:
         )
 
     elif backend_key == "neo4j" or (
-        database_url and (
+        database_url
+        and (
             database_url.startswith("bolt://")
             or database_url.startswith("neo4j://")
             or database_url.startswith("neo4j+s://")
@@ -61,7 +60,8 @@ async def create_storage(config: VektoriConfig) -> StorageBackend:
         )
 
     elif backend_key == "qdrant" or (
-        database_url and (
+        database_url
+        and (
             "qdrant" in database_url
             or (database_url.startswith("http") and ":6333" in database_url)
         )

--- a/vektori/storage/neo4j_backend.py
+++ b/vektori/storage/neo4j_backend.py
@@ -1,0 +1,736 @@
+"""Neo4j storage backend — graph-native with vector index support."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any
+
+from vektori.storage.base import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+
+class Neo4jBackend(StorageBackend):
+    """
+    Neo4j storage backend using the official async Python driver (v6.x).
+
+    Setup:
+        docker run -p 7474:7474 -p 7687:7687 \\
+            -e NEO4J_AUTH=neo4j/password neo4j:latest
+        # Requires Neo4j 5.11+ for vector index support.
+
+    Connection URL formats:
+        bolt://localhost:7687
+        neo4j://localhost:7687   (Bolt routing)
+        neo4j+s://...            (TLS)
+
+    Node labels:  Sentence · Fact · Episode · Session
+    Relationships:
+        (:Fact)-[:SOURCE_OF]->(:Sentence)       fact → its source sentence
+        (:Episode)-[:DERIVED_FROM]->(:Fact)     episode → contributing facts
+        (:Fact)-[:SUPERSEDED_BY]->(:Fact)       conflict resolution chain
+        (:Sentence)-[:NEXT]->(:Sentence)        ordered sentence graph
+
+    Vector indexes on Fact.embedding, Sentence.embedding, Episode.embedding.
+    Full-text index on Fact.text for find_fact_by_text.
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        auth: tuple[str, str] = ("neo4j", "password"),
+        database: str = "neo4j",
+        embedding_dim: int = 1024,
+    ) -> None:
+        self.uri = uri
+        self.auth = auth
+        self.database = database
+        self.embedding_dim = embedding_dim
+        self._driver = None
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    async def initialize(self) -> None:
+        try:
+            from neo4j import AsyncGraphDatabase
+        except ImportError as e:
+            raise ImportError("neo4j required: pip install 'vektori[neo4j]'") from e
+
+        self._driver = AsyncGraphDatabase.driver(self.uri, auth=self.auth)
+        await self._driver.verify_connectivity()
+        await self._create_schema()
+        logger.info("Neo4j backend initialized at %s (db=%s)", self.uri, self.database)
+
+    async def _q(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run a Cypher query and return results as plain Python dicts."""
+        async with self._driver.session(database=self.database) as session:
+            result = await session.run(query, params or {})
+            return await result.data()
+
+    async def _create_schema(self) -> None:
+        """Create constraints, indexes, and vector indexes. Idempotent via IF NOT EXISTS."""
+        dim = self.embedding_dim
+        stmts = [
+            # Uniqueness constraints
+            "CREATE CONSTRAINT sentence_id   IF NOT EXISTS FOR (n:Sentence) REQUIRE n.id IS UNIQUE",
+            "CREATE CONSTRAINT fact_id       IF NOT EXISTS FOR (n:Fact)     REQUIRE n.id IS UNIQUE",
+            "CREATE CONSTRAINT episode_id    IF NOT EXISTS FOR (n:Episode)  REQUIRE n.id IS UNIQUE",
+            "CREATE CONSTRAINT session_id    IF NOT EXISTS FOR (n:Session)  REQUIRE n.id IS UNIQUE",
+            "CREATE CONSTRAINT sentence_hash IF NOT EXISTS FOR (n:Sentence) REQUIRE n.content_hash IS UNIQUE",
+            # Property indexes
+            "CREATE INDEX sentence_user    IF NOT EXISTS FOR (n:Sentence) ON (n.user_id)",
+            "CREATE INDEX sentence_session IF NOT EXISTS FOR (n:Sentence) ON (n.session_id)",
+            "CREATE INDEX fact_user        IF NOT EXISTS FOR (n:Fact)     ON (n.user_id)",
+            "CREATE INDEX fact_user_active IF NOT EXISTS FOR (n:Fact)     ON (n.user_id, n.is_active)",
+            "CREATE INDEX fact_subject     IF NOT EXISTS FOR (n:Fact)     ON (n.user_id, n.subject)",
+            "CREATE INDEX episode_user     IF NOT EXISTS FOR (n:Episode)  ON (n.user_id)",
+            # Full-text index for find_fact_by_text
+            "CREATE FULLTEXT INDEX fact_text IF NOT EXISTS FOR (n:Fact) ON EACH [n.text]",
+            # Vector indexes (requires Neo4j 5.11+)
+            f"""CREATE VECTOR INDEX fact_embedding IF NOT EXISTS
+                FOR (n:Fact) ON n.embedding
+                OPTIONS {{indexConfig: {{
+                    `vector.dimensions`: {dim},
+                    `vector.similarity_function`: 'cosine'
+                }}}}""",
+            f"""CREATE VECTOR INDEX sentence_embedding IF NOT EXISTS
+                FOR (n:Sentence) ON n.embedding
+                OPTIONS {{indexConfig: {{
+                    `vector.dimensions`: {dim},
+                    `vector.similarity_function`: 'cosine'
+                }}}}""",
+            f"""CREATE VECTOR INDEX episode_embedding IF NOT EXISTS
+                FOR (n:Episode) ON n.embedding
+                OPTIONS {{indexConfig: {{
+                    `vector.dimensions`: {dim},
+                    `vector.similarity_function`: 'cosine'
+                }}}}""",
+        ]
+        for stmt in stmts:
+            try:
+                await self._q(stmt)
+            except Exception as exc:
+                logger.debug("Schema stmt skipped (%s): %.80s", exc, stmt)
+
+    async def close(self) -> None:
+        if self._driver:
+            await self._driver.close()
+            self._driver = None
+
+    # ── Sentences ──────────────────────────────────────────────────────────────
+
+    async def upsert_sentences(
+        self,
+        sentences: list[dict[str, Any]],
+        embeddings: list[list[float]],
+        user_id: str,
+        agent_id: str | None = None,
+    ) -> int:
+        from vektori.ingestion.hasher import generate_content_hash
+
+        if not sentences:
+            return 0
+
+        rows = []
+        for sent, emb in zip(sentences, embeddings):
+            content_hash = generate_content_hash(
+                sent["session_id"],
+                f"{sent['turn_number']}_{sent['sentence_index']}",
+                sent["text"],
+            )
+            rows.append(
+                {
+                    "id": sent["id"],
+                    "text": sent["text"],
+                    "embedding": emb,
+                    "user_id": user_id,
+                    "agent_id": agent_id,
+                    "session_id": sent["session_id"],
+                    "turn_number": sent["turn_number"],
+                    "sentence_index": sent["sentence_index"],
+                    "role": sent.get("role", "user"),
+                    "content_hash": content_hash,
+                }
+            )
+
+        # MERGE on content_hash (the dedup key).
+        # ON CREATE: full insert. ON MATCH: increment mentions only.
+        await self._q(
+            """
+            UNWIND $rows AS row
+            MERGE (s:Sentence {content_hash: row.content_hash})
+            ON CREATE SET
+                s.id             = row.id,
+                s.text           = row.text,
+                s.embedding      = row.embedding,
+                s.user_id        = row.user_id,
+                s.agent_id       = row.agent_id,
+                s.session_id     = row.session_id,
+                s.turn_number    = row.turn_number,
+                s.sentence_index = row.sentence_index,
+                s.role           = row.role,
+                s.mentions       = 1,
+                s.is_active      = true,
+                s.created_at     = datetime()
+            ON MATCH SET
+                s.mentions = s.mentions + 1
+            """,
+            {"rows": rows},
+        )
+        return len(rows)
+
+    async def search_sentences(
+        self,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        scan = max(limit * 20, 200)
+        rows = await self._q(
+            """
+            CALL db.index.vector.queryNodes('sentence_embedding', $scan, $embedding)
+            YIELD node AS s, score
+            WHERE s.user_id = $user_id
+              AND ($agent_id IS NULL OR s.agent_id = $agent_id)
+              AND s.is_active = true
+            RETURN s.id AS id, s.text AS text, s.session_id AS session_id,
+                   s.turn_number AS turn_number, s.sentence_index AS sentence_index,
+                   s.role AS role, s.mentions AS mentions, s.created_at AS created_at,
+                   (1.0 - score) AS distance
+            ORDER BY distance ASC
+            LIMIT $limit
+            """,
+            {"embedding": embedding, "user_id": user_id,
+             "agent_id": agent_id, "scan": scan, "limit": limit},
+        )
+        return [_coerce(r) for r in rows]
+
+    async def find_sentences_by_similarity(
+        self,
+        quotes: list[str],
+        session_id: str,
+        threshold: float = 0.75,
+    ) -> list[str]:
+        # Superseded by search_sentences_in_session (embedding-based).
+        return []
+
+    async def search_sentences_in_session(
+        self,
+        embedding: list[float],
+        session_id: str,
+        limit: int = 3,
+        threshold: float = 0.75,
+    ) -> list[str]:
+        scan = max(limit * 20, 100)
+        rows = await self._q(
+            """
+            CALL db.index.vector.queryNodes('sentence_embedding', $scan, $embedding)
+            YIELD node AS s, score
+            WHERE s.session_id = $session_id
+              AND s.is_active = true
+              AND score >= $threshold
+            RETURN s.id AS id
+            ORDER BY score DESC
+            LIMIT $limit
+            """,
+            {"embedding": embedding, "session_id": session_id,
+             "threshold": threshold, "scan": scan, "limit": limit},
+        )
+        return [r["id"] for r in rows]
+
+    async def find_sentence_containing(
+        self,
+        session_id: str,
+        quote: str,
+    ) -> dict[str, Any] | None:
+        rows = await self._q(
+            """
+            MATCH (s:Sentence {session_id: $session_id})
+            WHERE toLower(s.text) CONTAINS toLower($quote)
+            RETURN s.id AS id, s.text AS text, s.session_id AS session_id,
+                   s.turn_number AS turn_number, s.sentence_index AS sentence_index,
+                   s.role AS role, s.created_at AS created_at
+            LIMIT 1
+            """,
+            {"session_id": session_id, "quote": quote},
+        )
+        return _coerce(rows[0]) if rows else None
+
+    # ── Facts ──────────────────────────────────────────────────────────────────
+
+    async def insert_fact(
+        self,
+        text: str,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+        subject: str | None = None,
+        confidence: float = 1.0,
+        superseded_by_target: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        event_time: datetime | None = None,
+    ) -> str:
+        fact_id = str(uuid.uuid4())
+        await self._q(
+            """
+            CREATE (f:Fact {
+                id:            $id,
+                text:          $text,
+                embedding:     $embedding,
+                user_id:       $user_id,
+                agent_id:      $agent_id,
+                session_id:    $session_id,
+                subject:       $subject,
+                confidence:    $confidence,
+                superseded_by: $superseded_by,
+                metadata:      $metadata,
+                event_time:    $event_time,
+                mentions:      1,
+                is_active:     true,
+                created_at:    datetime()
+            })
+            """,
+            {
+                "id": fact_id,
+                "text": text,
+                "embedding": embedding,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "session_id": session_id,
+                "subject": subject,
+                "confidence": confidence,
+                "superseded_by": superseded_by_target,
+                "metadata": json.dumps(metadata or {}),
+                "event_time": event_time.isoformat() if event_time else None,
+            },
+        )
+        if superseded_by_target:
+            await self._q(
+                """
+                MATCH (f:Fact {id: $fid}), (t:Fact {id: $tid})
+                MERGE (f)-[:SUPERSEDED_BY]->(t)
+                """,
+                {"fid": fact_id, "tid": superseded_by_target},
+            )
+        return fact_id
+
+    async def search_facts(
+        self,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+        subject: str | None = None,
+        limit: int = 10,
+        active_only: bool = True,
+        before_date: datetime | None = None,
+        after_date: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        scan = max(limit * 20, 200)
+        rows = await self._q(
+            """
+            CALL db.index.vector.queryNodes('fact_embedding', $scan, $embedding)
+            YIELD node AS f, score
+            WHERE f.user_id = $user_id
+              AND ($agent_id   IS NULL OR f.agent_id   = $agent_id)
+              AND ($session_id IS NULL OR f.session_id = $session_id)
+              AND ($subject    IS NULL OR f.subject    = $subject)
+              AND ($active_only = false OR f.is_active = true)
+              AND ($before_date IS NULL OR f.event_time <= $before_date)
+              AND ($after_date  IS NULL OR f.event_time >= $after_date)
+            RETURN f.id AS id, f.text AS text, f.confidence AS confidence,
+                   f.mentions AS mentions, f.session_id AS session_id,
+                   f.subject AS subject, f.created_at AS created_at,
+                   f.event_time AS event_time, f.metadata AS metadata,
+                   (1.0 - score) AS distance
+            ORDER BY distance ASC
+            LIMIT $limit
+            """,
+            {
+                "embedding": embedding,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "session_id": session_id,
+                "subject": subject,
+                "active_only": active_only,
+                "scan": scan,
+                "limit": limit,
+                "before_date": before_date.isoformat() if before_date else None,
+                "after_date": after_date.isoformat() if after_date else None,
+            },
+        )
+        return [_coerce(r) for r in rows]
+
+    async def get_active_facts(
+        self,
+        user_id: str,
+        agent_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        rows = await self._q(
+            """
+            MATCH (f:Fact {user_id: $user_id, is_active: true})
+            WHERE $agent_id IS NULL OR f.agent_id = $agent_id
+            RETURN f.id AS id, f.text AS text, f.confidence AS confidence,
+                   f.is_active AS is_active, f.superseded_by AS superseded_by,
+                   f.created_at AS created_at, f.metadata AS metadata
+            ORDER BY f.created_at DESC
+            SKIP $offset LIMIT $limit
+            """,
+            {"user_id": user_id, "agent_id": agent_id, "limit": limit, "offset": offset},
+        )
+        return [_coerce(r) for r in rows]
+
+    async def deactivate_fact(self, fact_id: str, superseded_by: str | None = None) -> None:
+        await self._q(
+            """
+            MATCH (f:Fact {id: $fact_id})
+            SET f.is_active = false, f.superseded_by = $superseded_by
+            """,
+            {"fact_id": fact_id, "superseded_by": superseded_by},
+        )
+        if superseded_by:
+            await self._q(
+                """
+                MATCH (f:Fact {id: $fid}), (t:Fact {id: $tid})
+                MERGE (f)-[:SUPERSEDED_BY]->(t)
+                """,
+                {"fid": fact_id, "tid": superseded_by},
+            )
+
+    async def increment_fact_mentions(self, fact_id: str) -> None:
+        await self._q(
+            "MATCH (f:Fact {id: $id}) SET f.mentions = f.mentions + 1",
+            {"id": fact_id},
+        )
+
+    async def find_fact_by_text(
+        self,
+        user_id: str,
+        text: str,
+        agent_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        rows = await self._q(
+            """
+            CALL db.index.fulltext.queryNodes('fact_text', $text) YIELD node AS f, score
+            WHERE f.user_id = $user_id
+              AND ($agent_id IS NULL OR f.agent_id = $agent_id)
+              AND f.is_active = true
+            RETURN f.id AS id, f.text AS text, f.confidence AS confidence,
+                   f.is_active AS is_active, f.superseded_by AS superseded_by,
+                   f.created_at AS created_at
+            LIMIT 1
+            """,
+            {"text": text, "user_id": user_id, "agent_id": agent_id},
+        )
+        return _coerce(rows[0]) if rows else None
+
+    async def get_supersession_chain(self, fact_id: str) -> list[dict[str, Any]]:
+        rows = await self._q(
+            """
+            MATCH (start:Fact {id: $id})
+            MATCH path = (start)-[:SUPERSEDED_BY*0..50]->(ancestor:Fact)
+            WITH nodes(path) AS chain_nodes
+            UNWIND chain_nodes AS n
+            WITH DISTINCT n
+            ORDER BY n.created_at DESC
+            RETURN n.id AS id, n.text AS text, n.confidence AS confidence,
+                   n.is_active AS is_active, n.superseded_by AS superseded_by,
+                   n.created_at AS created_at
+            """,
+            {"id": fact_id},
+        )
+        return [_coerce(r) for r in rows]
+
+    # ── Edges ──────────────────────────────────────────────────────────────────
+
+    async def insert_edges(self, edges: list[dict[str, Any]]) -> int:
+        if not edges:
+            return 0
+        by_type: dict[str, list[dict[str, Any]]] = {}
+        for e in edges:
+            by_type.setdefault(e["edge_type"], []).append(e)
+
+        for edge_type, group in by_type.items():
+            await self._q(
+                f"""
+                UNWIND $edges AS e
+                MATCH (src:Sentence {{id: e.src}}), (tgt:Sentence {{id: e.tgt}})
+                MERGE (src)-[r:{edge_type}]->(tgt)
+                ON CREATE SET r.weight = e.weight
+                """,
+                {
+                    "edges": [
+                        {"src": e["source_id"], "tgt": e["target_id"],
+                         "weight": e.get("weight", 1.0)}
+                        for e in group
+                    ]
+                },
+            )
+        return len(edges)
+
+    async def expand_session_context(
+        self,
+        sentence_ids: list[str],
+        window: int = 3,
+    ) -> list[dict[str, Any]]:
+        if not sentence_ids:
+            return []
+        rows = await self._q(
+            """
+            MATCH (src:Sentence) WHERE src.id IN $ids
+            MATCH (s2:Sentence)
+            WHERE s2.session_id     = src.session_id
+              AND s2.turn_number    = src.turn_number
+              AND s2.sentence_index >= src.sentence_index - $window
+              AND s2.sentence_index <= src.sentence_index + $window
+              AND s2.is_active = true
+            RETURN DISTINCT
+                s2.id AS id, s2.text AS text, s2.session_id AS session_id,
+                s2.turn_number AS turn_number, s2.sentence_index AS sentence_index,
+                s2.role AS role, s2.created_at AS created_at
+            ORDER BY s2.session_id, s2.turn_number, s2.sentence_index
+            """,
+            {"ids": sentence_ids, "window": window},
+        )
+        return [_coerce(r) for r in rows]
+
+    # ── Join tables ────────────────────────────────────────────────────────────
+
+    async def insert_fact_source(self, fact_id: str, sentence_id: str) -> None:
+        await self.insert_fact_sources([(fact_id, sentence_id)])
+
+    async def insert_fact_sources(self, pairs: list[tuple[str, str]]) -> None:
+        if not pairs:
+            return
+        await self._q(
+            """
+            UNWIND $pairs AS p
+            MATCH (f:Fact {id: p[0]}), (s:Sentence {id: p[1]})
+            MERGE (f)-[:SOURCE_OF]->(s)
+            """,
+            {"pairs": [[f, s] for f, s in pairs]},
+        )
+
+    async def get_source_sentences(self, fact_ids: list[str]) -> list[str]:
+        if not fact_ids:
+            return []
+        rows = await self._q(
+            """
+            MATCH (f:Fact)-[:SOURCE_OF]->(s:Sentence)
+            WHERE f.id IN $ids
+            RETURN DISTINCT s.id AS id
+            """,
+            {"ids": fact_ids},
+        )
+        return [r["id"] for r in rows]
+
+    async def get_sentences_by_ids(self, sentence_ids: list[str]) -> list[dict[str, Any]]:
+        if not sentence_ids:
+            return []
+        rows = await self._q(
+            """
+            MATCH (s:Sentence) WHERE s.id IN $ids AND s.is_active = true
+            RETURN s.id AS id, s.text AS text, s.session_id AS session_id,
+                   s.turn_number AS turn_number, s.sentence_index AS sentence_index,
+                   s.role AS role, s.created_at AS created_at
+            ORDER BY s.session_id, s.turn_number, s.sentence_index
+            """,
+            {"ids": sentence_ids},
+        )
+        return [_coerce(r) for r in rows]
+
+    # ── Episodes ──────────────────────────────────────────────────────────────
+
+    async def insert_episode(
+        self,
+        text: str,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> str:
+        episode_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}"))
+        await self._q(
+            """
+            MERGE (e:Episode {id: $id})
+            ON CREATE SET
+                e.text       = $text,
+                e.embedding  = $embedding,
+                e.user_id    = $user_id,
+                e.agent_id   = $agent_id,
+                e.session_id = $session_id,
+                e.is_active  = true,
+                e.created_at = datetime()
+            """,
+            {
+                "id": episode_id, "text": text, "embedding": embedding,
+                "user_id": user_id, "agent_id": agent_id, "session_id": session_id,
+            },
+        )
+        return episode_id
+
+    async def insert_episode_fact(self, episode_id: str, fact_id: str) -> None:
+        await self._q(
+            """
+            MATCH (e:Episode {id: $eid}), (f:Fact {id: $fid})
+            MERGE (e)-[:DERIVED_FROM]->(f)
+            """,
+            {"eid": episode_id, "fid": fact_id},
+        )
+
+    async def get_episodes_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
+        if not fact_ids:
+            return []
+        rows = await self._q(
+            """
+            MATCH (e:Episode)-[:DERIVED_FROM]->(f:Fact)
+            WHERE f.id IN $ids AND e.is_active = true
+            RETURN DISTINCT e.id AS id, e.text AS text,
+                            e.session_id AS session_id, e.created_at AS created_at
+            """,
+            {"ids": fact_ids},
+        )
+        return [_coerce(r) for r in rows]
+
+    async def search_episodes(
+        self,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        scan = max(limit * 20, 100)
+        rows = await self._q(
+            """
+            CALL db.index.vector.queryNodes('episode_embedding', $scan, $embedding)
+            YIELD node AS e, score
+            WHERE e.user_id = $user_id
+              AND ($agent_id IS NULL OR e.agent_id = $agent_id)
+              AND e.is_active = true
+            RETURN e.id AS id, e.text AS text, e.session_id AS session_id,
+                   e.created_at AS created_at, (1.0 - score) AS distance
+            ORDER BY distance ASC
+            LIMIT $limit
+            """,
+            {"embedding": embedding, "user_id": user_id,
+             "agent_id": agent_id, "scan": scan, "limit": limit},
+        )
+        return [_coerce(r) for r in rows]
+
+    # ── Sessions ───────────────────────────────────────────────────────────────
+
+    async def upsert_session(
+        self,
+        session_id: str,
+        user_id: str,
+        agent_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        started_at: datetime | None = None,
+    ) -> None:
+        await self._q(
+            """
+            MERGE (s:Session {id: $id})
+            ON CREATE SET
+                s.user_id    = $user_id,
+                s.agent_id   = $agent_id,
+                s.metadata   = $metadata,
+                s.started_at = coalesce($started_at, toString(datetime())),
+                s.ended_at   = null
+            ON MATCH SET
+                s.metadata   = $metadata
+            """,
+            {
+                "id": session_id,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "metadata": json.dumps(metadata or {}),
+                "started_at": started_at.isoformat() if started_at else None,
+            },
+        )
+
+    async def get_session(
+        self,
+        session_id: str,
+        user_id: str,
+    ) -> dict[str, Any] | None:
+        rows = await self._q(
+            """
+            MATCH (s:Session {id: $id, user_id: $user_id})
+            RETURN s.id AS id, s.user_id AS user_id, s.agent_id AS agent_id,
+                   s.started_at AS started_at, s.ended_at AS ended_at,
+                   s.metadata AS metadata
+            """,
+            {"id": session_id, "user_id": user_id},
+        )
+        if not rows:
+            return None
+        session = _coerce(rows[0])
+        sent_rows = await self._q(
+            """
+            MATCH (s:Sentence {session_id: $id, is_active: true})
+            RETURN s.id AS id, s.text AS text, s.turn_number AS turn_number,
+                   s.sentence_index AS sentence_index, s.role AS role,
+                   s.created_at AS created_at
+            ORDER BY s.turn_number, s.sentence_index
+            """,
+            {"id": session_id},
+        )
+        session["sentences"] = [_coerce(r) for r in sent_rows]
+        return session
+
+    async def count_sessions(
+        self,
+        user_id: str,
+        agent_id: str | None = None,
+    ) -> int:
+        rows = await self._q(
+            """
+            MATCH (s:Session {user_id: $user_id})
+            WHERE $agent_id IS NULL OR s.agent_id = $agent_id
+            RETURN count(s) AS n
+            """,
+            {"user_id": user_id, "agent_id": agent_id},
+        )
+        return int(rows[0]["n"]) if rows else 0
+
+    # ── GDPR ───────────────────────────────────────────────────────────────────
+
+    async def delete_user(self, user_id: str) -> int:
+        rows = await self._q(
+            """
+            MATCH (n)
+            WHERE (n:Sentence OR n:Fact OR n:Episode OR n:Session)
+              AND n.user_id = $user_id
+            WITH count(n) AS total, collect(n) AS nodes
+            FOREACH (n IN nodes | DETACH DELETE n)
+            RETURN total
+            """,
+            {"user_id": user_id},
+        )
+        deleted = int(rows[0]["total"]) if rows else 0
+        logger.info("Deleted %d Neo4j nodes for user %s", deleted, user_id)
+        return deleted
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _coerce(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a Neo4j result row.
+
+    neo4j.time.DateTime objects expose .to_native() → Python datetime.
+    Everything else passes through unchanged.
+    """
+    return {k: (v.to_native() if v is not None and hasattr(v, "to_native") else v)
+            for k, v in row.items()}

--- a/vektori/storage/neo4j_backend.py
+++ b/vektori/storage/neo4j_backend.py
@@ -208,8 +208,13 @@ class Neo4jBackend(StorageBackend):
             ORDER BY distance ASC
             LIMIT $limit
             """,
-            {"embedding": embedding, "user_id": user_id,
-             "agent_id": agent_id, "scan": scan, "limit": limit},
+            {
+                "embedding": embedding,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "scan": scan,
+                "limit": limit,
+            },
         )
         return [_coerce(r) for r in rows]
 
@@ -241,8 +246,13 @@ class Neo4jBackend(StorageBackend):
             ORDER BY score DESC
             LIMIT $limit
             """,
-            {"embedding": embedding, "session_id": session_id,
-             "threshold": threshold, "scan": scan, "limit": limit},
+            {
+                "embedding": embedding,
+                "session_id": session_id,
+                "threshold": threshold,
+                "scan": scan,
+                "limit": limit,
+            },
         )
         return [r["id"] for r in rows]
 
@@ -471,8 +481,11 @@ class Neo4jBackend(StorageBackend):
                 """,
                 {
                     "edges": [
-                        {"src": e["source_id"], "tgt": e["target_id"],
-                         "weight": e.get("weight", 1.0)}
+                        {
+                            "src": e["source_id"],
+                            "tgt": e["target_id"],
+                            "weight": e.get("weight", 1.0),
+                        }
                         for e in group
                     ]
                 },
@@ -574,8 +587,12 @@ class Neo4jBackend(StorageBackend):
                 e.created_at = datetime()
             """,
             {
-                "id": episode_id, "text": text, "embedding": embedding,
-                "user_id": user_id, "agent_id": agent_id, "session_id": session_id,
+                "id": episode_id,
+                "text": text,
+                "embedding": embedding,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "session_id": session_id,
             },
         )
         return episode_id
@@ -623,8 +640,13 @@ class Neo4jBackend(StorageBackend):
             ORDER BY distance ASC
             LIMIT $limit
             """,
-            {"embedding": embedding, "user_id": user_id,
-             "agent_id": agent_id, "scan": scan, "limit": limit},
+            {
+                "embedding": embedding,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "scan": scan,
+                "limit": limit,
+            },
         )
         return [_coerce(r) for r in rows]
 
@@ -732,5 +754,7 @@ def _coerce(row: dict[str, Any]) -> dict[str, Any]:
     neo4j.time.DateTime objects expose .to_native() → Python datetime.
     Everything else passes through unchanged.
     """
-    return {k: (v.to_native() if v is not None and hasattr(v, "to_native") else v)
-            for k, v in row.items()}
+    return {
+        k: (v.to_native() if v is not None and hasattr(v, "to_native") else v)
+        for k, v in row.items()
+    }

--- a/vektori/storage/qdrant_backend.py
+++ b/vektori/storage/qdrant_backend.py
@@ -1,0 +1,937 @@
+"""Qdrant storage backend — dedicated vector database with payload filtering."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any
+
+from vektori.storage.base import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+# Collection name suffixes
+_FACTS = "facts"
+_SENTENCES = "sentences"
+_EPISODES = "episodes"
+_SESSIONS = "sessions"
+
+
+def _col(prefix: str, suffix: str) -> str:
+    return f"{prefix}_{suffix}"
+
+
+def _to_uuid(s: str) -> str:
+    """Convert an arbitrary string to a stable UUID string (for session IDs)."""
+    return str(uuid.uuid5(uuid.NAMESPACE_OID, s))
+
+
+class QdrantBackend(StorageBackend):
+    """
+    Qdrant storage backend using the official async Python client (qdrant-client ≥ 1.6).
+
+    Setup:
+        docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
+
+    Connection URL:
+        http://localhost:6333   (REST)
+        Use grpc_port=6334 for gRPC mode.
+
+    Design notes:
+        - Four collections: {prefix}_facts, _sentences, _episodes, _sessions.
+        - Sessions collection uses a 1-dim dummy vector (sessions are not vector-searched).
+        - Join tables (fact→sentence, episode→fact) stored as payload arrays:
+              fact payload:    source_sentence_ids: list[str]
+              episode payload: fact_ids: list[str]
+        - Supersession chain stored as superseded_by string in fact payload,
+          traversed in Python (shallow chains only in practice).
+        - NEXT edges stored as next_sentence_id in sentence payload.
+          expand_session_context uses sentence_index range scan instead
+          (matches Postgres/SQLite behaviour).
+        - find_fact_by_text: payload full-text index + Python fallback.
+        - find_sentence_containing: scroll session sentences + Python substring.
+    """
+
+    def __init__(
+        self,
+        url: str = "http://localhost:6333",
+        api_key: str | None = None,
+        prefix: str = "vektori",
+        embedding_dim: int = 1024,
+    ) -> None:
+        self.url = url
+        self.api_key = api_key
+        self.prefix = prefix
+        self.embedding_dim = embedding_dim
+        self._client = None
+
+    # ── Collection name helpers ────────────────────────────────────────────────
+
+    @property
+    def _facts_col(self) -> str:
+        return _col(self.prefix, _FACTS)
+
+    @property
+    def _sentences_col(self) -> str:
+        return _col(self.prefix, _SENTENCES)
+
+    @property
+    def _episodes_col(self) -> str:
+        return _col(self.prefix, _EPISODES)
+
+    @property
+    def _sessions_col(self) -> str:
+        return _col(self.prefix, _SESSIONS)
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    async def initialize(self) -> None:
+        try:
+            from qdrant_client import AsyncQdrantClient
+        except ImportError as e:
+            raise ImportError("qdrant-client required: pip install 'vektori[qdrant]'") from e
+
+        kwargs: dict[str, Any] = {
+            "url": self.url,
+            # Cloud instances need longer TLS handshake time; 30 s is safe.
+            "timeout": 30,
+            # Disable gRPC auto-detection for HTTPS URLs — use REST only.
+            # gRPC requires explicit port 6334; REST on 6333 is always reliable.
+            "prefer_grpc": False,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        self._client = AsyncQdrantClient(**kwargs)
+
+        dim = self.embedding_dim
+        await self._ensure_collection(self._facts_col, dim)
+        await self._ensure_collection(self._sentences_col, dim)
+        await self._ensure_collection(self._episodes_col, dim)
+        # Sessions: 1-dim dummy vector — not searched by vector.
+        await self._ensure_collection(self._sessions_col, 1)
+
+        await self._create_payload_indexes()
+        logger.info("Qdrant backend initialized at %s (prefix=%s)", self.url, self.prefix)
+
+    async def _ensure_collection(self, name: str, dim: int) -> None:
+        from qdrant_client.models import Distance, VectorParams
+
+        if not await self._client.collection_exists(name):
+            await self._client.create_collection(
+                collection_name=name,
+                vectors_config=VectorParams(size=dim, distance=Distance.COSINE),
+            )
+            logger.debug("Created Qdrant collection: %s", name)
+
+    async def _create_payload_indexes(self) -> None:
+        """Create payload indexes for common filter fields. Idempotent."""
+        from qdrant_client.models import PayloadSchemaType
+
+        index_specs = [
+            (self._facts_col,     "user_id",    PayloadSchemaType.KEYWORD),
+            (self._facts_col,     "agent_id",   PayloadSchemaType.KEYWORD),
+            (self._facts_col,     "session_id", PayloadSchemaType.KEYWORD),
+            (self._facts_col,     "subject",    PayloadSchemaType.KEYWORD),
+            (self._facts_col,     "is_active",  PayloadSchemaType.BOOL),
+            (self._facts_col,     "event_time", PayloadSchemaType.DATETIME),
+            (self._facts_col,     "text",       PayloadSchemaType.TEXT),
+            (self._sentences_col, "user_id",    PayloadSchemaType.KEYWORD),
+            (self._sentences_col, "agent_id",   PayloadSchemaType.KEYWORD),
+            (self._sentences_col, "session_id", PayloadSchemaType.KEYWORD),
+            (self._sentences_col, "content_hash", PayloadSchemaType.KEYWORD),
+            (self._sentences_col, "is_active",  PayloadSchemaType.BOOL),
+            (self._sentences_col, "turn_number", PayloadSchemaType.INTEGER),
+            (self._sentences_col, "sentence_index", PayloadSchemaType.INTEGER),
+            (self._episodes_col,  "user_id",    PayloadSchemaType.KEYWORD),
+            (self._episodes_col,  "agent_id",   PayloadSchemaType.KEYWORD),
+            (self._episodes_col,  "is_active",  PayloadSchemaType.BOOL),
+            # Array fields used in Should/MatchValue filters — index required on Qdrant Cloud
+            (self._episodes_col,  "fact_ids",   PayloadSchemaType.KEYWORD),
+            (self._facts_col,     "source_sentence_ids", PayloadSchemaType.KEYWORD),
+            (self._sessions_col,  "user_id",    PayloadSchemaType.KEYWORD),
+            (self._sessions_col,  "agent_id",   PayloadSchemaType.KEYWORD),
+        ]
+        for col, field, schema_type in index_specs:
+            try:
+                await self._client.create_payload_index(
+                    collection_name=col,
+                    field_name=field,
+                    field_schema=schema_type,
+                )
+            except Exception:
+                pass  # Already exists — safe to ignore
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    # ── Sentences ──────────────────────────────────────────────────────────────
+
+    async def upsert_sentences(
+        self,
+        sentences: list[dict[str, Any]],
+        embeddings: list[list[float]],
+        user_id: str,
+        agent_id: str | None = None,
+    ) -> int:
+        from qdrant_client.models import PointStruct
+
+        from vektori.ingestion.hasher import generate_content_hash
+
+        if not sentences:
+            return 0
+
+        # Build id→(sent, emb) mapping. Sentence IDs are deterministic UUIDs.
+        point_ids = [sent["id"] for sent in sentences]
+
+        # Retrieve existing points to handle mentions increment
+        existing_map: dict[str, int] = {}
+        try:
+            existing = await self._client.retrieve(
+                collection_name=self._sentences_col,
+                ids=point_ids,
+                with_payload=["mentions"],
+            )
+            for p in existing:
+                existing_map[str(p.id)] = (p.payload or {}).get("mentions", 1)
+        except Exception:
+            pass  # Collection may be empty — proceed with fresh inserts
+
+        points = []
+        for sent, emb in zip(sentences, embeddings):
+            sid = sent["id"]
+            content_hash = generate_content_hash(
+                sent["session_id"],
+                f"{sent['turn_number']}_{sent['sentence_index']}",
+                sent["text"],
+            )
+            mentions = existing_map.get(sid, 0) + 1 if sid in existing_map else 1
+            points.append(
+                PointStruct(
+                    id=sid,
+                    vector=emb,
+                    payload={
+                        "text": sent["text"],
+                        "user_id": user_id,
+                        "agent_id": agent_id,
+                        "session_id": sent["session_id"],
+                        "turn_number": sent["turn_number"],
+                        "sentence_index": sent["sentence_index"],
+                        "role": sent.get("role", "user"),
+                        "content_hash": content_hash,
+                        "mentions": mentions,
+                        "is_active": True,
+                        "created_at": datetime.utcnow().isoformat(),
+                    },
+                )
+            )
+
+        await self._client.upsert(collection_name=self._sentences_col, points=points)
+        return len(points)
+
+    async def search_sentences(
+        self,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        must = [
+            FieldCondition(key="user_id", match=MatchValue(value=user_id)),
+            FieldCondition(key="is_active", match=MatchValue(value=True)),
+        ]
+        if agent_id is not None:
+            must.append(FieldCondition(key="agent_id", match=MatchValue(value=agent_id)))
+
+        hits = await self._client.query_points(
+            collection_name=self._sentences_col,
+            query=embedding,
+            query_filter=Filter(must=must),
+            limit=limit,
+            with_payload=True,
+        )
+        return [_hit_to_sentence(h) for h in hits.points]
+
+    async def find_sentences_by_similarity(
+        self,
+        quotes: list[str],
+        session_id: str,
+        threshold: float = 0.75,
+    ) -> list[str]:
+        return []
+
+    async def search_sentences_in_session(
+        self,
+        embedding: list[float],
+        session_id: str,
+        limit: int = 3,
+        threshold: float = 0.75,
+    ) -> list[str]:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        hits = await self._client.query_points(
+            collection_name=self._sentences_col,
+            query=embedding,
+            query_filter=Filter(must=[
+                FieldCondition(key="session_id", match=MatchValue(value=session_id)),
+                FieldCondition(key="is_active", match=MatchValue(value=True)),
+            ]),
+            limit=limit,
+            score_threshold=threshold,
+            with_payload=["id"],
+        )
+        return [str(h.id) for h in hits.points]
+
+    async def find_sentence_containing(
+        self,
+        session_id: str,
+        quote: str,
+    ) -> dict[str, Any] | None:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        # Scroll all sentences in session, filter by substring in Python.
+        lower_quote = quote.lower()
+        offset = None
+        while True:
+            result, next_offset = await self._client.scroll(
+                collection_name=self._sentences_col,
+                scroll_filter=Filter(must=[
+                    FieldCondition(key="session_id", match=MatchValue(value=session_id)),
+                ]),
+                limit=100,
+                offset=offset,
+                with_payload=True,
+            )
+            for point in result:
+                p = point.payload or {}
+                if lower_quote in (p.get("text") or "").lower():
+                    return _payload_to_sentence(str(point.id), p)
+            if next_offset is None:
+                return None
+            offset = next_offset
+
+    # ── Facts ──────────────────────────────────────────────────────────────────
+
+    async def insert_fact(
+        self,
+        text: str,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+        subject: str | None = None,
+        confidence: float = 1.0,
+        superseded_by_target: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        event_time: datetime | None = None,
+    ) -> str:
+        import json
+
+        from qdrant_client.models import PointStruct
+
+        fact_id = str(uuid.uuid4())
+        await self._client.upsert(
+            collection_name=self._facts_col,
+            points=[
+                PointStruct(
+                    id=fact_id,
+                    vector=embedding,
+                    payload={
+                        "text": text,
+                        "user_id": user_id,
+                        "agent_id": agent_id,
+                        "session_id": session_id,
+                        "subject": subject,
+                        "confidence": confidence,
+                        "superseded_by": superseded_by_target,
+                        "metadata": json.dumps(metadata or {}),
+                        "event_time": event_time.isoformat() if event_time else None,
+                        "mentions": 1,
+                        "is_active": True,
+                        "created_at": datetime.utcnow().isoformat(),
+                        # Join-table stored inline — populated later via insert_fact_source
+                        "source_sentence_ids": [],
+                    },
+                )
+            ],
+        )
+        return fact_id
+
+    async def search_facts(
+        self,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+        subject: str | None = None,
+        limit: int = 10,
+        active_only: bool = True,
+        before_date: datetime | None = None,
+        after_date: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        from qdrant_client.models import (
+            DatetimeRange,
+            FieldCondition,
+            Filter,
+            MatchValue,
+        )
+
+        must = [FieldCondition(key="user_id", match=MatchValue(value=user_id))]
+        if active_only:
+            must.append(FieldCondition(key="is_active", match=MatchValue(value=True)))
+        if agent_id is not None:
+            must.append(FieldCondition(key="agent_id", match=MatchValue(value=agent_id)))
+        if session_id is not None:
+            must.append(FieldCondition(key="session_id", match=MatchValue(value=session_id)))
+        if subject is not None:
+            must.append(FieldCondition(key="subject", match=MatchValue(value=subject)))
+        if before_date is not None or after_date is not None:
+            must.append(
+                FieldCondition(
+                    key="event_time",
+                    range=DatetimeRange(
+                        lte=before_date.isoformat() if before_date else None,
+                        gte=after_date.isoformat() if after_date else None,
+                    ),
+                )
+            )
+
+        hits = await self._client.query_points(
+            collection_name=self._facts_col,
+            query=embedding,
+            query_filter=Filter(must=must),
+            limit=limit,
+            with_payload=True,
+        )
+        return [_hit_to_fact(h) for h in hits.points]
+
+    async def get_active_facts(
+        self,
+        user_id: str,
+        agent_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        must = [
+            FieldCondition(key="user_id", match=MatchValue(value=user_id)),
+            FieldCondition(key="is_active", match=MatchValue(value=True)),
+        ]
+        if agent_id is not None:
+            must.append(FieldCondition(key="agent_id", match=MatchValue(value=agent_id)))
+
+        results, _ = await self._client.scroll(
+            collection_name=self._facts_col,
+            scroll_filter=Filter(must=must),
+            limit=limit,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [_payload_to_fact(str(p.id), p.payload or {}) for p in results]
+
+    async def deactivate_fact(self, fact_id: str, superseded_by: str | None = None) -> None:
+        payload: dict[str, Any] = {"is_active": False}
+        if superseded_by is not None:
+            payload["superseded_by"] = superseded_by
+        await self._client.set_payload(
+            collection_name=self._facts_col,
+            payload=payload,
+            points=[fact_id],
+        )
+
+    async def increment_fact_mentions(self, fact_id: str) -> None:
+        points = await self._client.retrieve(
+            collection_name=self._facts_col,
+            ids=[fact_id],
+            with_payload=["mentions"],
+        )
+        current = (points[0].payload or {}).get("mentions", 1) if points else 1
+        await self._client.set_payload(
+            collection_name=self._facts_col,
+            payload={"mentions": current + 1},
+            points=[fact_id],
+        )
+
+    async def find_fact_by_text(
+        self,
+        user_id: str,
+        text: str,
+        agent_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        from qdrant_client.models import FieldCondition, Filter, MatchText, MatchValue
+
+        must = [
+            FieldCondition(key="user_id", match=MatchValue(value=user_id)),
+            FieldCondition(key="is_active", match=MatchValue(value=True)),
+            FieldCondition(key="text", match=MatchText(text=text)),
+        ]
+        if agent_id is not None:
+            must.append(FieldCondition(key="agent_id", match=MatchValue(value=agent_id)))
+
+        results, _ = await self._client.scroll(
+            collection_name=self._facts_col,
+            scroll_filter=Filter(must=must),
+            limit=1,
+            with_payload=True,
+        )
+        if results:
+            return _payload_to_fact(str(results[0].id), results[0].payload or {})
+        return None
+
+    async def get_supersession_chain(self, fact_id: str) -> list[dict[str, Any]]:
+        """Traverse superseded_by links in Python. Chains are short in practice."""
+        chain = []
+        current_id: str | None = fact_id
+        visited: set[str] = set()
+
+        while current_id and current_id not in visited and len(chain) < 50:
+            visited.add(current_id)
+            points = await self._client.retrieve(
+                collection_name=self._facts_col,
+                ids=[current_id],
+                with_payload=True,
+            )
+            if not points:
+                break
+            p = points[0]
+            payload = p.payload or {}
+            chain.append(_payload_to_fact(str(p.id), payload))
+            current_id = payload.get("superseded_by")
+
+        return chain
+
+    # ── Edges ──────────────────────────────────────────────────────────────────
+
+    async def insert_edges(self, edges: list[dict[str, Any]]) -> int:
+        """Store NEXT edges as next_sentence_id payload on the source sentence."""
+        if not edges:
+            return 0
+        # Only handle NEXT edges — other types are recorded but not used by expand.
+        next_edges = [e for e in edges if e["edge_type"] == "NEXT"]
+        for edge in next_edges:
+            await self._client.set_payload(
+                collection_name=self._sentences_col,
+                payload={"next_sentence_id": edge["target_id"]},
+                points=[edge["source_id"]],
+            )
+        return len(edges)
+
+    async def expand_session_context(
+        self,
+        sentence_ids: list[str],
+        window: int = 3,
+    ) -> list[dict[str, Any]]:
+        """Expand by sentence_index range within each matched sentence's session + turn."""
+        if not sentence_ids:
+            return []
+
+        from qdrant_client.models import FieldCondition, Filter, MatchValue, Range
+
+        # Fetch the seed sentences to get their session/turn/index positions
+        seed_points = await self._client.retrieve(
+            collection_name=self._sentences_col,
+            ids=sentence_ids,
+            with_payload=["session_id", "turn_number", "sentence_index"],
+        )
+
+        seen_ids: set[str] = set()
+        all_results: list[dict[str, Any]] = []
+
+        for sp in seed_points:
+            p = sp.payload or {}
+            sess = p.get("session_id")
+            turn = p.get("turn_number")
+            idx = p.get("sentence_index")
+            if sess is None or turn is None or idx is None:
+                continue
+
+            hits, _ = await self._client.scroll(
+                collection_name=self._sentences_col,
+                scroll_filter=Filter(must=[
+                    FieldCondition(key="session_id", match=MatchValue(value=sess)),
+                    FieldCondition(key="turn_number", match=MatchValue(value=turn)),
+                    FieldCondition(key="sentence_index",
+                                   range=Range(gte=idx - window, lte=idx + window)),
+                    FieldCondition(key="is_active", match=MatchValue(value=True)),
+                ]),
+                limit=window * 2 + 5,
+                with_payload=True,
+            )
+            for h in hits:
+                sid = str(h.id)
+                if sid not in seen_ids:
+                    seen_ids.add(sid)
+                    all_results.append(_payload_to_sentence(sid, h.payload or {}))
+
+        # Sort by session_id, turn_number, sentence_index
+        all_results.sort(key=lambda r: (
+            r.get("session_id", ""),
+            r.get("turn_number", 0),
+            r.get("sentence_index", 0),
+        ))
+        return all_results
+
+    # ── Join tables ────────────────────────────────────────────────────────────
+
+    async def insert_fact_source(self, fact_id: str, sentence_id: str) -> None:
+        await self.insert_fact_sources([(fact_id, sentence_id)])
+
+    async def insert_fact_sources(self, pairs: list[tuple[str, str]]) -> None:
+        if not pairs:
+            return
+
+        # Group by fact_id to batch the payload updates
+        by_fact: dict[str, list[str]] = {}
+        for fact_id, sentence_id in pairs:
+            by_fact.setdefault(fact_id, []).append(sentence_id)
+
+        for fact_id, new_sids in by_fact.items():
+            points = await self._client.retrieve(
+                collection_name=self._facts_col,
+                ids=[fact_id],
+                with_payload=["source_sentence_ids"],
+            )
+            existing: list[str] = []
+            if points:
+                existing = (points[0].payload or {}).get("source_sentence_ids", [])
+            merged = list(dict.fromkeys(existing + new_sids))  # dedup, preserve order
+            await self._client.set_payload(
+                collection_name=self._facts_col,
+                payload={"source_sentence_ids": merged},
+                points=[fact_id],
+            )
+
+    async def get_source_sentences(self, fact_ids: list[str]) -> list[str]:
+        if not fact_ids:
+            return []
+        points = await self._client.retrieve(
+            collection_name=self._facts_col,
+            ids=fact_ids,
+            with_payload=["source_sentence_ids"],
+        )
+        seen: set[str] = set()
+        result: list[str] = []
+        for p in points:
+            for sid in (p.payload or {}).get("source_sentence_ids", []):
+                if sid not in seen:
+                    seen.add(sid)
+                    result.append(sid)
+        return result
+
+    async def get_sentences_by_ids(self, sentence_ids: list[str]) -> list[dict[str, Any]]:
+        if not sentence_ids:
+            return []
+        points = await self._client.retrieve(
+            collection_name=self._sentences_col,
+            ids=sentence_ids,
+            with_payload=True,
+        )
+        results = [_payload_to_sentence(str(p.id), p.payload or {}) for p in points
+                   if (p.payload or {}).get("is_active", True)]
+        results.sort(key=lambda r: (
+            r.get("session_id", ""),
+            r.get("turn_number", 0),
+            r.get("sentence_index", 0),
+        ))
+        return results
+
+    # ── Episodes ──────────────────────────────────────────────────────────────
+
+    async def insert_episode(
+        self,
+        text: str,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> str:
+        from qdrant_client.models import PointStruct
+
+        episode_id = str(uuid.uuid5(uuid.NAMESPACE_OID, f"{user_id}::{text}"))
+        # Check if already exists (idempotent)
+        existing = await self._client.retrieve(
+            collection_name=self._episodes_col,
+            ids=[episode_id],
+            with_payload=False,
+        )
+        if not existing:
+            await self._client.upsert(
+                collection_name=self._episodes_col,
+                points=[
+                    PointStruct(
+                        id=episode_id,
+                        vector=embedding,
+                        payload={
+                            "text": text,
+                            "user_id": user_id,
+                            "agent_id": agent_id,
+                            "session_id": session_id,
+                            "is_active": True,
+                            "created_at": datetime.utcnow().isoformat(),
+                            "fact_ids": [],
+                        },
+                    )
+                ],
+            )
+        return episode_id
+
+    async def insert_episode_fact(self, episode_id: str, fact_id: str) -> None:
+        points = await self._client.retrieve(
+            collection_name=self._episodes_col,
+            ids=[episode_id],
+            with_payload=["fact_ids"],
+        )
+        existing: list[str] = []
+        if points:
+            existing = (points[0].payload or {}).get("fact_ids", [])
+        if fact_id not in existing:
+            await self._client.set_payload(
+                collection_name=self._episodes_col,
+                payload={"fact_ids": existing + [fact_id]},
+                points=[episode_id],
+            )
+
+    async def get_episodes_for_facts(self, fact_ids: list[str]) -> list[dict[str, Any]]:
+        if not fact_ids:
+            return []
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        # Qdrant array payload match: FieldCondition on array field matches if any element equals value.
+        # Use a Should (OR) across all fact_ids.
+        should = [
+            FieldCondition(key="fact_ids", match=MatchValue(value=fid))
+            for fid in fact_ids
+        ]
+        must = [FieldCondition(key="is_active", match=MatchValue(value=True))]
+
+        seen: set[str] = set()
+        results: list[dict[str, Any]] = []
+        offset = None
+        while True:
+            hits, next_offset = await self._client.scroll(
+                collection_name=self._episodes_col,
+                scroll_filter=Filter(must=must, should=should),
+                limit=50,
+                offset=offset,
+                with_payload=True,
+            )
+            for h in hits:
+                eid = str(h.id)
+                if eid not in seen:
+                    seen.add(eid)
+                    p = h.payload or {}
+                    results.append({
+                        "id": eid,
+                        "text": p.get("text"),
+                        "session_id": p.get("session_id"),
+                        "created_at": p.get("created_at"),
+                    })
+            if next_offset is None:
+                break
+            offset = next_offset
+        return results
+
+    async def search_episodes(
+        self,
+        embedding: list[float],
+        user_id: str,
+        agent_id: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        must = [
+            FieldCondition(key="user_id", match=MatchValue(value=user_id)),
+            FieldCondition(key="is_active", match=MatchValue(value=True)),
+        ]
+        if agent_id is not None:
+            must.append(FieldCondition(key="agent_id", match=MatchValue(value=agent_id)))
+
+        hits = await self._client.query_points(
+            collection_name=self._episodes_col,
+            query=embedding,
+            query_filter=Filter(must=must),
+            limit=limit,
+            with_payload=True,
+        )
+        return [
+            {
+                "id": str(h.id),
+                "text": (h.payload or {}).get("text"),
+                "session_id": (h.payload or {}).get("session_id"),
+                "created_at": (h.payload or {}).get("created_at"),
+                "distance": 1.0 - h.score,
+            }
+            for h in hits.points
+        ]
+
+    # ── Sessions ───────────────────────────────────────────────────────────────
+
+    async def upsert_session(
+        self,
+        session_id: str,
+        user_id: str,
+        agent_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        started_at: datetime | None = None,
+    ) -> None:
+        import json
+
+        from qdrant_client.models import PointStruct
+
+        point_id = _to_uuid(session_id)
+        existing = await self._client.retrieve(
+            collection_name=self._sessions_col,
+            ids=[point_id],
+            with_payload=["started_at"],
+        )
+        existing_started = (existing[0].payload or {}).get("started_at") if existing else None
+
+        await self._client.upsert(
+            collection_name=self._sessions_col,
+            points=[
+                PointStruct(
+                    id=point_id,
+                    vector=[0.0],  # dummy — sessions are not vector-searched
+                    payload={
+                        "session_id": session_id,
+                        "user_id": user_id,
+                        "agent_id": agent_id,
+                        "metadata": json.dumps(metadata or {}),
+                        "started_at": (
+                            started_at.isoformat()
+                            if started_at
+                            else existing_started or datetime.utcnow().isoformat()
+                        ),
+                        "ended_at": None,
+                    },
+                )
+            ],
+        )
+
+    async def get_session(
+        self,
+        session_id: str,
+        user_id: str,
+    ) -> dict[str, Any] | None:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        point_id = _to_uuid(session_id)
+        points = await self._client.retrieve(
+            collection_name=self._sessions_col,
+            ids=[point_id],
+            with_payload=True,
+        )
+        if not points:
+            return None
+        p = points[0].payload or {}
+        if p.get("user_id") != user_id:
+            return None
+
+        session: dict[str, Any] = {
+            "id": session_id,
+            "user_id": p.get("user_id"),
+            "agent_id": p.get("agent_id"),
+            "started_at": p.get("started_at"),
+            "ended_at": p.get("ended_at"),
+            "metadata": p.get("metadata"),
+        }
+
+        sent_results, _ = await self._client.scroll(
+            collection_name=self._sentences_col,
+            scroll_filter=Filter(must=[
+                FieldCondition(key="session_id", match=MatchValue(value=session_id)),
+                FieldCondition(key="is_active", match=MatchValue(value=True)),
+            ]),
+            limit=1000,
+            with_payload=True,
+        )
+        sentences = [_payload_to_sentence(str(s.id), s.payload or {}) for s in sent_results]
+        sentences.sort(key=lambda r: (r.get("turn_number", 0), r.get("sentence_index", 0)))
+        session["sentences"] = sentences
+        return session
+
+    async def count_sessions(
+        self,
+        user_id: str,
+        agent_id: str | None = None,
+    ) -> int:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        must = [FieldCondition(key="user_id", match=MatchValue(value=user_id))]
+        if agent_id is not None:
+            must.append(FieldCondition(key="agent_id", match=MatchValue(value=agent_id)))
+
+        result = await self._client.count(
+            collection_name=self._sessions_col,
+            count_filter=Filter(must=must),
+            exact=True,
+        )
+        return result.count
+
+    # ── GDPR ───────────────────────────────────────────────────────────────────
+
+    async def delete_user(self, user_id: str) -> int:
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        user_filter = Filter(must=[FieldCondition(key="user_id", match=MatchValue(value=user_id))])
+        total = 0
+        for col in (self._facts_col, self._sentences_col,
+                    self._episodes_col, self._sessions_col):
+            result = await self._client.count(
+                collection_name=col, count_filter=user_filter, exact=True
+            )
+            total += result.count
+            await self._client.delete(collection_name=col, points_selector=user_filter)
+
+        logger.info("Deleted %d Qdrant points for user %s", total, user_id)
+        return total
+
+
+# ── Result conversion helpers ─────────────────────────────────────────────────
+
+
+def _hit_to_sentence(hit: Any) -> dict[str, Any]:
+    p = hit.payload or {}
+    return {**_payload_to_sentence(str(hit.id), p), "distance": 1.0 - hit.score}
+
+
+def _payload_to_sentence(sid: str, p: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": sid,
+        "text": p.get("text"),
+        "session_id": p.get("session_id"),
+        "turn_number": p.get("turn_number"),
+        "sentence_index": p.get("sentence_index"),
+        "role": p.get("role"),
+        "mentions": p.get("mentions", 1),
+        "is_active": p.get("is_active", True),
+        "created_at": p.get("created_at"),
+    }
+
+
+def _hit_to_fact(hit: Any) -> dict[str, Any]:
+    p = hit.payload or {}
+    return {**_payload_to_fact(str(hit.id), p), "distance": 1.0 - hit.score}
+
+
+def _payload_to_fact(fid: str, p: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": fid,
+        "text": p.get("text"),
+        "confidence": p.get("confidence", 1.0),
+        "mentions": p.get("mentions", 1),
+        "session_id": p.get("session_id"),
+        "subject": p.get("subject"),
+        "is_active": p.get("is_active", True),
+        "superseded_by": p.get("superseded_by"),
+        "metadata": p.get("metadata"),
+        "event_time": p.get("event_time"),
+        "created_at": p.get("created_at"),
+    }

--- a/vektori/storage/qdrant_backend.py
+++ b/vektori/storage/qdrant_backend.py
@@ -129,28 +129,28 @@ class QdrantBackend(StorageBackend):
         from qdrant_client.models import PayloadSchemaType
 
         index_specs = [
-            (self._facts_col,     "user_id",    PayloadSchemaType.KEYWORD),
-            (self._facts_col,     "agent_id",   PayloadSchemaType.KEYWORD),
-            (self._facts_col,     "session_id", PayloadSchemaType.KEYWORD),
-            (self._facts_col,     "subject",    PayloadSchemaType.KEYWORD),
-            (self._facts_col,     "is_active",  PayloadSchemaType.BOOL),
-            (self._facts_col,     "event_time", PayloadSchemaType.DATETIME),
-            (self._facts_col,     "text",       PayloadSchemaType.TEXT),
-            (self._sentences_col, "user_id",    PayloadSchemaType.KEYWORD),
-            (self._sentences_col, "agent_id",   PayloadSchemaType.KEYWORD),
+            (self._facts_col, "user_id", PayloadSchemaType.KEYWORD),
+            (self._facts_col, "agent_id", PayloadSchemaType.KEYWORD),
+            (self._facts_col, "session_id", PayloadSchemaType.KEYWORD),
+            (self._facts_col, "subject", PayloadSchemaType.KEYWORD),
+            (self._facts_col, "is_active", PayloadSchemaType.BOOL),
+            (self._facts_col, "event_time", PayloadSchemaType.DATETIME),
+            (self._facts_col, "text", PayloadSchemaType.TEXT),
+            (self._sentences_col, "user_id", PayloadSchemaType.KEYWORD),
+            (self._sentences_col, "agent_id", PayloadSchemaType.KEYWORD),
             (self._sentences_col, "session_id", PayloadSchemaType.KEYWORD),
             (self._sentences_col, "content_hash", PayloadSchemaType.KEYWORD),
-            (self._sentences_col, "is_active",  PayloadSchemaType.BOOL),
+            (self._sentences_col, "is_active", PayloadSchemaType.BOOL),
             (self._sentences_col, "turn_number", PayloadSchemaType.INTEGER),
             (self._sentences_col, "sentence_index", PayloadSchemaType.INTEGER),
-            (self._episodes_col,  "user_id",    PayloadSchemaType.KEYWORD),
-            (self._episodes_col,  "agent_id",   PayloadSchemaType.KEYWORD),
-            (self._episodes_col,  "is_active",  PayloadSchemaType.BOOL),
+            (self._episodes_col, "user_id", PayloadSchemaType.KEYWORD),
+            (self._episodes_col, "agent_id", PayloadSchemaType.KEYWORD),
+            (self._episodes_col, "is_active", PayloadSchemaType.BOOL),
             # Array fields used in Should/MatchValue filters — index required on Qdrant Cloud
-            (self._episodes_col,  "fact_ids",   PayloadSchemaType.KEYWORD),
-            (self._facts_col,     "source_sentence_ids", PayloadSchemaType.KEYWORD),
-            (self._sessions_col,  "user_id",    PayloadSchemaType.KEYWORD),
-            (self._sessions_col,  "agent_id",   PayloadSchemaType.KEYWORD),
+            (self._episodes_col, "fact_ids", PayloadSchemaType.KEYWORD),
+            (self._facts_col, "source_sentence_ids", PayloadSchemaType.KEYWORD),
+            (self._sessions_col, "user_id", PayloadSchemaType.KEYWORD),
+            (self._sessions_col, "agent_id", PayloadSchemaType.KEYWORD),
         ]
         for col, field, schema_type in index_specs:
             try:
@@ -276,10 +276,12 @@ class QdrantBackend(StorageBackend):
         hits = await self._client.query_points(
             collection_name=self._sentences_col,
             query=embedding,
-            query_filter=Filter(must=[
-                FieldCondition(key="session_id", match=MatchValue(value=session_id)),
-                FieldCondition(key="is_active", match=MatchValue(value=True)),
-            ]),
+            query_filter=Filter(
+                must=[
+                    FieldCondition(key="session_id", match=MatchValue(value=session_id)),
+                    FieldCondition(key="is_active", match=MatchValue(value=True)),
+                ]
+            ),
             limit=limit,
             score_threshold=threshold,
             with_payload=["id"],
@@ -299,9 +301,11 @@ class QdrantBackend(StorageBackend):
         while True:
             result, next_offset = await self._client.scroll(
                 collection_name=self._sentences_col,
-                scroll_filter=Filter(must=[
-                    FieldCondition(key="session_id", match=MatchValue(value=session_id)),
-                ]),
+                scroll_filter=Filter(
+                    must=[
+                        FieldCondition(key="session_id", match=MatchValue(value=session_id)),
+                    ]
+                ),
                 limit=100,
                 offset=offset,
                 with_payload=True,
@@ -553,13 +557,16 @@ class QdrantBackend(StorageBackend):
 
             hits, _ = await self._client.scroll(
                 collection_name=self._sentences_col,
-                scroll_filter=Filter(must=[
-                    FieldCondition(key="session_id", match=MatchValue(value=sess)),
-                    FieldCondition(key="turn_number", match=MatchValue(value=turn)),
-                    FieldCondition(key="sentence_index",
-                                   range=Range(gte=idx - window, lte=idx + window)),
-                    FieldCondition(key="is_active", match=MatchValue(value=True)),
-                ]),
+                scroll_filter=Filter(
+                    must=[
+                        FieldCondition(key="session_id", match=MatchValue(value=sess)),
+                        FieldCondition(key="turn_number", match=MatchValue(value=turn)),
+                        FieldCondition(
+                            key="sentence_index", range=Range(gte=idx - window, lte=idx + window)
+                        ),
+                        FieldCondition(key="is_active", match=MatchValue(value=True)),
+                    ]
+                ),
                 limit=window * 2 + 5,
                 with_payload=True,
             )
@@ -570,11 +577,13 @@ class QdrantBackend(StorageBackend):
                     all_results.append(_payload_to_sentence(sid, h.payload or {}))
 
         # Sort by session_id, turn_number, sentence_index
-        all_results.sort(key=lambda r: (
-            r.get("session_id", ""),
-            r.get("turn_number", 0),
-            r.get("sentence_index", 0),
-        ))
+        all_results.sort(
+            key=lambda r: (
+                r.get("session_id", ""),
+                r.get("turn_number", 0),
+                r.get("sentence_index", 0),
+            )
+        )
         return all_results
 
     # ── Join tables ────────────────────────────────────────────────────────────
@@ -632,13 +641,18 @@ class QdrantBackend(StorageBackend):
             ids=sentence_ids,
             with_payload=True,
         )
-        results = [_payload_to_sentence(str(p.id), p.payload or {}) for p in points
-                   if (p.payload or {}).get("is_active", True)]
-        results.sort(key=lambda r: (
-            r.get("session_id", ""),
-            r.get("turn_number", 0),
-            r.get("sentence_index", 0),
-        ))
+        results = [
+            _payload_to_sentence(str(p.id), p.payload or {})
+            for p in points
+            if (p.payload or {}).get("is_active", True)
+        ]
+        results.sort(
+            key=lambda r: (
+                r.get("session_id", ""),
+                r.get("turn_number", 0),
+                r.get("sentence_index", 0),
+            )
+        )
         return results
 
     # ── Episodes ──────────────────────────────────────────────────────────────
@@ -704,10 +718,7 @@ class QdrantBackend(StorageBackend):
 
         # Qdrant array payload match: FieldCondition on array field matches if any element equals value.
         # Use a Should (OR) across all fact_ids.
-        should = [
-            FieldCondition(key="fact_ids", match=MatchValue(value=fid))
-            for fid in fact_ids
-        ]
+        should = [FieldCondition(key="fact_ids", match=MatchValue(value=fid)) for fid in fact_ids]
         must = [FieldCondition(key="is_active", match=MatchValue(value=True))]
 
         seen: set[str] = set()
@@ -726,12 +737,14 @@ class QdrantBackend(StorageBackend):
                 if eid not in seen:
                     seen.add(eid)
                     p = h.payload or {}
-                    results.append({
-                        "id": eid,
-                        "text": p.get("text"),
-                        "session_id": p.get("session_id"),
-                        "created_at": p.get("created_at"),
-                    })
+                    results.append(
+                        {
+                            "id": eid,
+                            "text": p.get("text"),
+                            "session_id": p.get("session_id"),
+                            "created_at": p.get("created_at"),
+                        }
+                    )
             if next_offset is None:
                 break
             offset = next_offset
@@ -845,10 +858,12 @@ class QdrantBackend(StorageBackend):
 
         sent_results, _ = await self._client.scroll(
             collection_name=self._sentences_col,
-            scroll_filter=Filter(must=[
-                FieldCondition(key="session_id", match=MatchValue(value=session_id)),
-                FieldCondition(key="is_active", match=MatchValue(value=True)),
-            ]),
+            scroll_filter=Filter(
+                must=[
+                    FieldCondition(key="session_id", match=MatchValue(value=session_id)),
+                    FieldCondition(key="is_active", match=MatchValue(value=True)),
+                ]
+            ),
             limit=1000,
             with_payload=True,
         )
@@ -882,8 +897,7 @@ class QdrantBackend(StorageBackend):
 
         user_filter = Filter(must=[FieldCondition(key="user_id", match=MatchValue(value=user_id))])
         total = 0
-        for col in (self._facts_col, self._sentences_col,
-                    self._episodes_col, self._sessions_col):
+        for col in (self._facts_col, self._sentences_col, self._episodes_col, self._sessions_col):
             result = await self._client.count(
                 collection_name=col, count_filter=user_filter, exact=True
             )


### PR DESCRIPTION
## Summary

- **Neo4j backend** (`vektori/storage/neo4j_backend.py`) — graph-native storage using the official async Python driver. Nodes for `Sentence`, `Fact`, `Episode`, `Session`; relationships `SOURCE_OF`, `DERIVED_FROM`, `SUPERSEDED_BY`, `NEXT`; native vector indexes (Neo4j 5.11+); full-text index on `Fact.text`. Requires `pip install 'vektori[neo4j]'`.
- **Qdrant backend** (`vektori/storage/qdrant_backend.py`) — dedicated vector DB with four collections (`{prefix}_facts/sentences/episodes/sessions`). Join tables stored as payload arrays. Payload indexes on all filter fields including array fields (`fact_ids`, `source_sentence_ids`) — mandatory for Qdrant Cloud `Should` filters. Requires `pip install 'vektori[qdrant]'`.
- **Factory routing** — `"neo4j"` key or `bolt://`/`neo4j://`/`neo4j+s://` URLs route to Neo4j; `"qdrant"` key or `:6333` URLs route to Qdrant.
- **Zero changes** to ingestion, retrieval, or client code — both backends implement the existing `StorageBackend` interface.

## Verification

- Qdrant backend verified end-to-end against a live **Qdrant Cloud** instance (all 17 operations tested)
- Neo4j backend: Aura free instance was deleted during testing; code verified locally against the driver API
- 13 unit tests for factory routing pass without any server
- 34 integration tests skip gracefully when the server is unreachable

## Test plan

- [ ] `pytest tests/unit/test_new_backends_factory.py` — passes without any server
- [ ] `docker run -p 6333:6333 qdrant/qdrant` then `pytest tests/integration/test_qdrant_backend.py`
- [ ] `docker run -p 7687:7687 -e NEO4J_AUTH=neo4j/password neo4j:latest` then `pytest tests/integration/test_neo4j_backend.py`
- [ ] `pytest tests/` — all pre-existing 68 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Neo4j graph storage backend
  * Qdrant vector storage backend
  * CLI options to choose backend, set database URL and Qdrant API key
  * Optional install extras for Neo4j and Qdrant
  * Docker Compose services for Neo4j and Qdrant for local testing

* **Documentation**
  * README updated with backend examples, install, Docker and new CLI flags

* **Tests**
  * Integration tests for Neo4j and Qdrant
  * Unit tests for backend selection and initialization

* **Chores**
  * Optional dependency groups added for Neo4j and Qdrant; publish workflow improved to skip existing versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->