### PR TITLE
add NVIDIA NIM support with embedder and LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,21 @@ v = Vektori(embedding_model="bge:BAAI/bge-m3")
 v = Vektori(extraction_model="litellm:groq/llama3-8b-8192")
 ```
 
+## NVIDIA NIM - GPU-optimized models via [NVIDIA NIM](https://build.nvidia.com).
+```python
+# NVIDIA embedding models (Matryoshka: 384-2048 dimensions)
+v = Vektori(
+    embedding_model="nvidia:llama-nemotron-embed-1b-v2",
+    embedding_dimension=1024,  # Optional: 384, 512, 768, 1024, or 2048
+)
+
+# NVIDIA LLM models (nvidia/ prefix auto-added)
+v = Vektori(extraction_model="nvidia:llama-3.3-nemotron-super-49b-v1")
+
+# Third-party models hosted on NVIDIA NIM (use full path)
+v = Vektori(extraction_model="nvidia:z-ai/glm5")
+
+```
 ---
 
 ## Why Not Mem0 / Zep?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ anthropic = ["anthropic>=0.20", "voyageai>=0.2"]
 sentence-transformers = ["sentence-transformers>=2.6"]
 bge = ["FlagEmbedding>=1.2"]
 litellm = ["litellm>=1.30"]
+nvidia = ["openai>=1.12"]  # NVIDIA NIM uses OpenAI-compatible API
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -57,6 +58,7 @@ all = [
     "sentence-transformers>=2.6",
     "FlagEmbedding>=1.2",
     "litellm>=1.30",
+    "openai>=1.12",  # NVIDIA NIM support
 ]
 
 [project.scripts]

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -2,27 +2,25 @@
 
 import pytest
 
-from vektori.models.factory import create_embedder, create_llm
+from vektori.models.anthropic import AnthropicLLM
+from vektori.models.factory import LLM_REGISTRY, create_embedder, create_llm
+from vektori.models.nvidia import DEFAULT_EMBEDDING_MODEL, NvidiaEmbedder, NvidiaLLM
+from vektori.models.ollama import OllamaEmbedder, OllamaLLM
+from vektori.models.openai import OpenAIEmbedder, OpenAILLM
 
 
 def test_create_openai_embedder():
-    from vektori.models.openai import OpenAIEmbedder
-
     embedder = create_embedder("openai:text-embedding-3-small")
     assert isinstance(embedder, OpenAIEmbedder)
     assert embedder.model == "text-embedding-3-small"
 
 
 def test_create_openai_embedder_default_model():
-    from vektori.models.openai import OpenAIEmbedder
-
     embedder = create_embedder("openai")
     assert isinstance(embedder, OpenAIEmbedder)
 
 
 def test_create_ollama_embedder():
-    from vektori.models.ollama import OllamaEmbedder
-
     embedder = create_embedder("ollama:nomic-embed-text")
     assert isinstance(embedder, OllamaEmbedder)
     assert embedder.model == "nomic-embed-text"
@@ -41,23 +39,17 @@ def test_unknown_embedding_provider_raises():
 
 
 def test_create_openai_llm():
-    from vektori.models.openai import OpenAILLM
-
     llm = create_llm("openai:gpt-4o-mini")
     assert isinstance(llm, OpenAILLM)
     assert llm.model == "gpt-4o-mini"
 
 
 def test_create_ollama_llm():
-    from vektori.models.ollama import OllamaLLM
-
     llm = create_llm("ollama:llama3")
     assert isinstance(llm, OllamaLLM)
 
 
 def test_create_anthropic_llm():
-    from vektori.models.anthropic import AnthropicLLM
-
     llm = create_llm("anthropic:claude-haiku-4-5-20251001")
     assert isinstance(llm, AnthropicLLM)
 
@@ -68,15 +60,27 @@ def test_unknown_llm_provider_raises():
 
 
 def test_create_nvidia_embedder_default_model():
-    from vektori.models.nvidia import NvidiaEmbedder, DEFAULT_EMBEDDING_MODEL
-
     embedder = create_embedder("nvidia")
     assert isinstance(embedder, NvidiaEmbedder)
-    assert embedder.model == DEFAULT_EMBEDDING_MODEL  # "nvidia/llama-nemotron-embed-1b-v2"
+    assert embedder.model == DEFAULT_EMBEDDING_MODEL
 
-    # Parallel LLM factory assertion: verify nvidia is registered and creates a valid instance
-    from vektori.models.factory import create_llm, LLM_REGISTRY
+def test_create_nvidia_embedder_custom_dimensions():
+    embedder = create_embedder("nvidia:llama-nemotron-embed-1b-v2", dimensions=1024)
+    assert isinstance(embedder, NvidiaEmbedder)
+    assert embedder.dimension == 1024  # Matryoshka support
 
+def test_create_nvidia_llm():
+    llm = create_llm("nvidia:llama-3.3-nemotron-super-49b-v1")
+    assert isinstance(llm, NvidiaLLM)
+    assert llm.model == "nvidia/llama-3.3-nemotron-super-49b-v1"
+
+def test_create_nvidia_llm_default_model():
+    llm = create_llm("nvidia")
+    assert isinstance(llm, NvidiaLLM)
+    assert "nvidia/llama-3.3-nemotron-super-49b-v1" == llm.model
+
+def test_nvidia_llm_registered():
+    """Verify NVIDIA LLM is registered in factory."""
     assert "nvidia" in LLM_REGISTRY, "nvidia should be registered in LLM_REGISTRY"
     llm = create_llm("nvidia")
     assert llm is not None, "create_llm('nvidia') should return a valid instance"

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -66,9 +66,20 @@ def test_unknown_llm_provider_raises():
     with pytest.raises(ValueError, match="Unknown LLM provider"):
         create_llm("nonexistent:model")
 
+
 def test_create_nvidia_embedder_default_model():
     from vektori.models.nvidia import NvidiaEmbedder, DEFAULT_EMBEDDING_MODEL
 
     embedder = create_embedder("nvidia")
     assert isinstance(embedder, NvidiaEmbedder)
     assert embedder.model == DEFAULT_EMBEDDING_MODEL  # "nvidia/llama-nemotron-embed-1b-v2"
+
+    # Parallel LLM factory assertion: verify nvidia is registered and creates a valid instance
+    from vektori.models.factory import create_llm, LLM_REGISTRY
+
+    assert "nvidia" in LLM_REGISTRY, "nvidia should be registered in LLM_REGISTRY"
+    llm = create_llm("nvidia")
+    assert llm is not None, "create_llm('nvidia') should return a valid instance"
+    assert "Nvidia" in llm.__class__.__name__, (
+        f"LLM class name should include 'Nvidia', got {llm.__class__.__name__}"
+    )

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -65,3 +65,10 @@ def test_create_anthropic_llm():
 def test_unknown_llm_provider_raises():
     with pytest.raises(ValueError, match="Unknown LLM provider"):
         create_llm("nonexistent:model")
+
+def test_create_nvidia_embedder_default_model():
+    from vektori.models.nvidia import NvidiaEmbedder, DEFAULT_EMBEDDING_MODEL
+
+    embedder = create_embedder("nvidia")
+    assert isinstance(embedder, NvidiaEmbedder)
+    assert embedder.model == DEFAULT_EMBEDDING_MODEL  # "nvidia/llama-nemotron-embed-1b-v2"

--- a/vektori/models/factory.py
+++ b/vektori/models/factory.py
@@ -20,6 +20,7 @@ EMBEDDING_REGISTRY: dict[str, str] = {
     "cloudflare": "vektori.models.cloudflare.CloudflareEmbedder",
     # LiteLLM: 100+ providers — Together AI, Cohere, Azure, Ollama, etc.
     "litellm": "vektori.models.litellm_embedder.LiteLLMEmbedder",
+    "nvidia": "vektori.models.nvidia.NvidiaEmbedder",
 }
 
 LLM_REGISTRY: dict[str, str] = {
@@ -31,6 +32,7 @@ LLM_REGISTRY: dict[str, str] = {
     "gemini": "vektori.models.gemini.GeminiLLM",  # Direct Gemini API
     # LiteLLM: single interface for 100+ providers — recommended for extraction
     "litellm": "vektori.models.litellm_provider.LiteLLMProvider",
+    "nvidia": "vektori.models.nvidia.NvidiaLLM",
 }
 
 

--- a/vektori/models/nvidia.py
+++ b/vektori/models/nvidia.py
@@ -6,34 +6,34 @@ for embedding and text generation via an OpenAI-compatible API.
 Get API key: https://build.nvidia.com
 
 Usage:
-    v = Vektori(
-        embedding_model="nvidia:llama-nemotron-embed-1b-v2",
-        extraction_model="nvidia:llama-3.3-nemotron-super-49b-v1",
-    )
+v = Vektori(
+    embedding_model="nvidia:llama-nemotron-embed-1b-v2",
+    extraction_model="nvidia:llama-3.3-nemotron-super-49b-v1",
+)
 
 Environment:
-    NVIDIA_API_KEY - Your NVIDIA API key (required)
+NVIDIA_API_KEY - Your NVIDIA API key (required)
 
 Models:
-    Embeddings (llama-nemotron-embed-1b-v2 is recommended default):
-    - llama-nemotron-embed-1b-v2: 2048 dim, 8192 tokens, multilingual, Matryoshka
-    - llama-3.2-nv-embedqa-1b-v2: 2048 dim, 8192 tokens, QA-optimized
-    - baai/bge-m3: 1024 dim, 8192 tokens, multilingual, dense+sparse+multi-vector
-    - nv-embed-v1: 4096 dim, 32k tokens, generalist
-    - nv-embedqa-e5-v5: 1024 dim, 512 tokens, fast
+Embeddings (llama-nemotron-embed-1b-v2 is recommended default):
+- llama-nemotron-embed-1b-v2: 2048 dim, 8192 tokens, multilingual, Matryoshka
+- llama-3.2-nv-embedqa-1b-v2: 2048 dim, 8192 tokens, QA-optimized
+- baai/bge-m3: 1024 dim, 8192 tokens, multilingual, dense+sparse+multi-vector
+- nv-embed-v1: 4096 dim, 32k tokens, generalist
+- nv-embedqa-e5-v5: 1024 dim, 512 tokens, fast
 
-    LLMs:
-    - llama-3.3-nemotron-super-49b-v1: High quality extraction (default)
-    - llama-3.1-nemotron-ultra-253b-v1: Largest NVIDIA model
-    - nemotron-4-mini-hindi-4b-instruct: Fast, efficient
-    - z-ai/glm5: GLM-5, multilingual LLM
-    - z-ai/glm4.7: GLM-4.7, multilingual LLM
-    - google/gemma-4-31b-it: Google's Gemma 4 31B instruction tuned
-    - minimaxai/minimax-m2.7: MiniMax M2.7 model
-    - moonshotai/kimi-k2.5: Moonshot Kimi K2.5
-    - moonshotai/kimi-k2-instruct: Moonshot Kimi K2 instruction
-    - deepseek-ai/deepseek-v3.1: DeepSeek V3.1
-    - qwen/qwen3-coder-480b-a35b-instruct: Qwen3 Coder 480B
+LLMs:
+- llama-3.3-nemotron-super-49b-v1: High quality extraction (default)
+- llama-3.1-nemotron-ultra-253b-v1: Largest NVIDIA model
+- nemotron-4-mini-hindi-4b-instruct: Fast, efficient
+- z-ai/glm5: GLM-5, multilingual LLM
+- z-ai/glm4.7: GLM-4.7, multilingual LLM
+- google/gemma-4-31b-it: Google's Gemma 4 31B instruction tuned
+- minimaxai/minimax-m2.7: MiniMax M2.7 model
+- moonshotai/kimi-k2.5: Moonshot Kimi K2.5
+- moonshotai/kimi-k2-instruct: Moonshot Kimi K2 instruction
+- deepseek-ai/deepseek-v3.1: DeepSeek V3.1
+- qwen/qwen3-coder-480b-a35b-instruct: Qwen3 Coder 480B
 """
 
 from __future__ import annotations
@@ -114,8 +114,21 @@ class NvidiaEmbedder(EmbeddingProvider):
             raw_model = f"nvidia/{raw_model}"
         self.model = raw_model
         self._api_key = api_key
-        self._custom_dims = dimensions
         self._client = None
+
+        # Validate dimensions parameter
+        if dimensions is not None:
+            if not isinstance(dimensions, int):
+                raise ValueError(f"dimensions must be an integer, got {type(dimensions).__name__}")
+            if dimensions <= 0:
+                raise ValueError(f"dimensions must be positive, got {dimensions}")
+            # Validate that dimensions is a supported size for Matryoshka models
+            supported_dims = {384, 512, 768, 1024, 2048}
+            if dimensions not in supported_dims:
+                raise ValueError(
+                    f"dimensions must be one of {sorted(supported_dims)}, got {dimensions}"
+                )
+        self._custom_dims = dimensions
 
     def _get_client(self):
         """Lazy initialization of OpenAI client configured for NVIDIA API."""
@@ -148,8 +161,21 @@ class NvidiaEmbedder(EmbeddingProvider):
         embeddings, returns the custom dimension. Otherwise returns the
         model's default dimension.
         """
-        if self._custom_dims and self.model in MATRYOSHKA_MODELS:
-            return self._custom_dims
+        # Validate _custom_dims in case __init__ was bypassed
+        if self._custom_dims is not None:
+            if not isinstance(self._custom_dims, int):
+                raise ValueError(
+                    f"_custom_dims must be an integer, got {type(self._custom_dims).__name__}"
+                )
+            if self._custom_dims <= 0:
+                raise ValueError(f"_custom_dims must be positive, got {self._custom_dims}")
+            supported_dims = {384, 512, 768, 1024, 2048}
+            if self._custom_dims not in supported_dims:
+                raise ValueError(
+                    f"_custom_dims must be one of {sorted(supported_dims)}, got {self._custom_dims}"
+                )
+            if self.model in MATRYOSHKA_MODELS:
+                return self._custom_dims
         return EMBEDDING_DIMENSIONS.get(self.model, 2048)
 
     async def embed(self, text: str) -> list[float]:
@@ -181,8 +207,21 @@ class NvidiaEmbedder(EmbeddingProvider):
         extra_body: dict[str, Any] = {}
 
         # Matryoshka models support custom dimensions
-        if self._custom_dims and self.model in MATRYOSHKA_MODELS:
-            extra_body["dimensions"] = self._custom_dims
+        # Validate dimensions before consuming (fail-fast if __init__ was bypassed)
+        if self._custom_dims is not None:
+            if not isinstance(self._custom_dims, int):
+                raise ValueError(
+                    f"_custom_dims must be an integer, got {type(self._custom_dims).__name__}"
+                )
+            if self._custom_dims <= 0:
+                raise ValueError(f"_custom_dims must be positive, got {self._custom_dims}")
+            supported_dims = {384, 512, 768, 1024, 2048}
+            if self._custom_dims not in supported_dims:
+                raise ValueError(
+                    f"_custom_dims must be one of {sorted(supported_dims)}, got {self._custom_dims}"
+                )
+            if self.model in MATRYOSHKA_MODELS:
+                extra_body["dimensions"] = self._custom_dims
 
         # Some NVIDIA embedding models require input_type parameter
         # "passage" is used for indexing, "query" for querying
@@ -224,7 +263,7 @@ class NvidiaLLM(LLMProvider):
 
     Args:
         model: Model name from NVIDIA catalog (e.g., "llama-3.3-nemotron-super-49b-v1"
-            for NVIDIA models, or full path like "z-ai/glm5" for third-party models).
+        for NVIDIA models, or full path like "z-ai/glm5" for third-party models).
         api_key: NVIDIA API key. Falls back to NVIDIA_API_KEY env var.
     """
 
@@ -290,12 +329,28 @@ class NvidiaLLM(LLMProvider):
             kwargs["max_tokens"] = max_tokens
 
         # Try JSON mode first (for structured extraction)
+        kwargs["response_format"] = {"type": "json_object"}
         try:
-            kwargs["response_format"] = {"type": "json_object"}
             response = await client.chat.completions.create(**kwargs)
-        except Exception:
-            # Fallback if model doesn't support JSON mode
-            del kwargs["response_format"]
-            response = await client.chat.completions.create(**kwargs)
+        except Exception as e:
+            # Only fallback if the error indicates JSON mode is unsupported
+            error_str = str(e).lower()
+            is_json_mode_error = (
+                "response_format" in error_str
+                or "json" in error_str
+                or "json_object" in error_str
+                or hasattr(e, "code")
+                and (
+                    "unsupported" in str(getattr(e, "code", "")).lower()
+                    or "invalid" in str(getattr(e, "code", "")).lower()
+                )
+            )
+            if is_json_mode_error:
+                # Fallback if model doesn't support JSON mode
+                del kwargs["response_format"]
+                response = await client.chat.completions.create(**kwargs)
+            else:
+                # Re-raise for auth, network, rate-limit, etc.
+                raise
 
         return response.choices[0].message.content or ""

--- a/vektori/models/nvidia.py
+++ b/vektori/models/nvidia.py
@@ -1,0 +1,301 @@
+"""NVIDIA NIM embedding and LLM providers.
+
+NVIDIA NIM (NVIDIA Inference Microservices) provides GPU-optimized models
+for embedding and text generation via an OpenAI-compatible API.
+
+Get API key: https://build.nvidia.com
+
+Usage:
+    v = Vektori(
+        embedding_model="nvidia:llama-nemotron-embed-1b-v2",
+        extraction_model="nvidia:llama-3.3-nemotron-super-49b-v1",
+    )
+
+Environment:
+    NVIDIA_API_KEY - Your NVIDIA API key (required)
+
+Models:
+    Embeddings (llama-nemotron-embed-1b-v2 is recommended default):
+    - llama-nemotron-embed-1b-v2: 2048 dim, 8192 tokens, multilingual, Matryoshka
+    - llama-3.2-nv-embedqa-1b-v2: 2048 dim, 8192 tokens, QA-optimized
+    - baai/bge-m3: 1024 dim, 8192 tokens, multilingual, dense+sparse+multi-vector
+    - nv-embed-v1: 4096 dim, 32k tokens, generalist
+    - nv-embedqa-e5-v5: 1024 dim, 512 tokens, fast
+
+    LLMs:
+    - llama-3.3-nemotron-super-49b-v1: High quality extraction (default)
+    - llama-3.1-nemotron-ultra-253b-v1: Largest NVIDIA model
+    - nemotron-4-mini-hindi-4b-instruct: Fast, efficient
+    - z-ai/glm5: GLM-5, multilingual LLM
+    - z-ai/glm4.7: GLM-4.7, multilingual LLM
+    - google/gemma-4-31b-it: Google's Gemma 4 31B instruction tuned
+    - minimaxai/minimax-m2.7: MiniMax M2.7 model
+    - moonshotai/kimi-k2.5: Moonshot Kimi K2.5
+    - moonshotai/kimi-k2-instruct: Moonshot Kimi K2 instruction
+    - deepseek-ai/deepseek-v3.1: DeepSeek V3.1
+    - qwen/qwen3-coder-480b-a35b-instruct: Qwen3 Coder 480B
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from vektori.models.base import EmbeddingProvider, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
+
+# Embedding dimensions for known NVIDIA models
+# Matryoshka models support multiple dimensions; max is shown
+EMBEDDING_DIMENSIONS = {
+    # Nemotron family (Matryoshka: 384, 512, 768, 1024, 2048)
+    "nvidia/llama-nemotron-embed-1b-v2": 2048,
+    "nvidia/llama-nemotron-embed-vl-1b-v2": 2048,
+    # NeMo Retriever family (Matryoshka: 384, 512, 768, 1024, 2048)
+    "nvidia/llama-3.2-nv-embedqa-1b-v2": 2048,
+    "nvidia/llama-3.2-nv-embedqa-1b-v1": 2048,
+    "nvidia/llama-3.2-nemoretriever-300m-embed-v2": 1024,
+    "nvidia/llama-3.2-nemoretriever-300m-embed-v1": 1024,
+    "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1": 2048,
+    # BAAI BGE-M3 (hosted on NVIDIA NIM)
+    "baai/bge-m3": 1024,
+    # Other models
+    "nvidia/nv-embed-v1": 4096,
+    "nvidia/nv-embedqa-e5-v5": 1024,
+    "nvidia/nv-embedcode-7b-v1": 4096,
+    "nvidia/nv-embedqa-e5-v4": 1024,
+    "nvidia/nvclip": 512,
+}
+
+# Models that support Matryoshka embeddings (configurable dimensions)
+MATRYOSHKA_MODELS = {
+    "nvidia/llama-nemotron-embed-1b-v2",
+    "nvidia/llama-nemotron-embed-vl-1b-v2",
+    "nvidia/llama-3.2-nv-embedqa-1b-v2",
+    "nvidia/llama-3.2-nv-embedqa-1b-v1",
+}
+
+DEFAULT_EMBEDDING_MODEL = "nvidia/llama-nemotron-embed-1b-v2"
+DEFAULT_LLM_MODEL = "nvidia/llama-3.3-nemotron-super-49b-v1"
+
+
+class NvidiaEmbedder(EmbeddingProvider):
+    """NVIDIA NIM embedding models via OpenAI-compatible API.
+
+    Supports all NVIDIA embedding models including:
+    - llama-nemotron-embed-1b-v2 (recommended): multilingual, 2048-dim, Matryoshka
+    - llama-3.2-nv-embedqa-1b-v2: QA-optimized, 2048-dim, Matryoshka
+    - nv-embed-v1: generalist, 4096-dim, 32k context
+    - nv-embedqa-e5-v5: fast, 1024-dim, 512 context
+
+    Matryoshka models support configurable output dimensions:
+    384, 512, 768, 1024, or 2048. Use the dimensions parameter or
+    embedding_dimension config to set custom dimensions.
+
+    Args:
+        model: Model name from NVIDIA catalog. Defaults to llama-nemotron-embed-1b-v2.
+        api_key: NVIDIA API key. Falls back to NVIDIA_API_KEY env var.
+        dimensions: Optional custom embedding dimensions for Matryoshka models.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        api_key: str | None = None,
+        dimensions: int | None = None,
+    ) -> None:
+        raw_model = model or DEFAULT_EMBEDDING_MODEL
+        # NVIDIA NIM requires full path with namespace prefix (e.g., "nvidia/" or "baai/")
+        # Add "nvidia/" prefix if model doesn't already have a namespace
+        if "/" not in raw_model:
+            raw_model = f"nvidia/{raw_model}"
+        self.model = raw_model
+        self._api_key = api_key
+        self._custom_dims = dimensions
+        self._client = None
+
+    def _get_client(self):
+        """Lazy initialization of OpenAI client configured for NVIDIA API."""
+        if self._client is None:
+            try:
+                from openai import AsyncOpenAI
+            except ImportError as e:
+                raise ImportError(
+                    "openai package required for NVIDIA NIM: pip install openai>=1.12"
+                ) from e
+
+            api_key = self._api_key or os.environ.get("NVIDIA_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "NVIDIA API key required. Set NVIDIA_API_KEY environment variable "
+                    "or pass api_key parameter."
+                )
+
+            self._client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=NVIDIA_BASE_URL,
+            )
+        return self._client
+
+    @property
+    def dimension(self) -> int:
+        """Return embedding dimension.
+
+        If custom dimensions were specified and the model supports Matryoshka
+        embeddings, returns the custom dimension. Otherwise returns the
+        model's default dimension.
+        """
+        if self._custom_dims and self.model in MATRYOSHKA_MODELS:
+            return self._custom_dims
+        return EMBEDDING_DIMENSIONS.get(self.model, 2048)
+
+    async def embed(self, text: str) -> list[float]:
+        """Embed a single text string.
+
+        Args:
+            text: Text to embed.
+
+        Returns:
+            Embedding vector as list of floats.
+        """
+        return (await self.embed_batch([text]))[0]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed multiple texts in a single API call.
+
+        Args:
+            texts: List of text strings to embed.
+
+        Returns:
+            List of embedding vectors, preserving input order.
+        """
+        if not texts:
+            return []
+
+        client = self._get_client()
+
+        # Build extra_body for NVIDIA-specific parameters
+        extra_body: dict[str, Any] = {}
+
+        # Matryoshka models support custom dimensions
+        if self._custom_dims and self.model in MATRYOSHKA_MODELS:
+            extra_body["dimensions"] = self._custom_dims
+
+        # Some NVIDIA embedding models require input_type parameter
+        # "passage" is used for indexing, "query" for querying
+        # We default to "passage" for general embedding use
+        if self.model in {
+            "nvidia/llama-nemotron-embed-1b-v2",
+            "nvidia/llama-nemotron-embed-vl-1b-v2",
+        }:
+            extra_body["input_type"] = "passage"
+
+        response = await client.embeddings.create(
+            input=texts,
+            model=self.model,
+            extra_body=extra_body if extra_body else None,
+        )
+
+        # Sort by index to preserve order
+        return [item.embedding for item in sorted(response.data, key=lambda x: x.index)]
+
+
+class NvidiaLLM(LLMProvider):
+    """NVIDIA NIM LLM for fact and episode extraction.
+
+    Supports all NVIDIA chat completion models and third-party models hosted
+    on NVIDIA NIM, including:
+    - nvidia/llama-3.3-nemotron-super-49b-v1 (default): High quality extraction
+    - nvidia/llama-3.1-nemotron-ultra-253b-v1: Largest NVIDIA model
+    - nvidia/nemotron-4-mini-hindi-4b-instruct: Fast, efficient
+    - z-ai/glm5: GLM-5 multilingual model
+    - z-ai/glm4.7: GLM-4.7 multilingual model
+    - google/gemma-4-31b-it: Google's Gemma 4 31B instruction tuned
+    - minimaxai/minimax-m2.7: MiniMax M2.7 model
+    - moonshotai/kimi-k2.5: Moonshot Kimi K2.5
+    - moonshotai/kimi-k2-instruct: Moonshot Kimi K2 instruction
+    - deepseek-ai/deepseek-v3.1: DeepSeek V3.1
+    - qwen/qwen3-coder-480b-a35b-instruct: Qwen3 Coder 480B
+
+    Uses OpenAI-compatible API with NVIDIA-specific base URL.
+
+    Args:
+        model: Model name from NVIDIA catalog (e.g., "llama-3.3-nemotron-super-49b-v1"
+            for NVIDIA models, or full path like "z-ai/glm5" for third-party models).
+        api_key: NVIDIA API key. Falls back to NVIDIA_API_KEY env var.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        raw_model = model or DEFAULT_LLM_MODEL
+        # NVIDIA NIM requires full path with namespace prefix (e.g., "nvidia/")
+        # Add "nvidia/" prefix if model doesn't already have a namespace
+        if "/" not in raw_model:
+            raw_model = f"nvidia/{raw_model}"
+        self.model = raw_model
+        self._api_key = api_key
+        self._client = None
+
+    def _get_client(self):
+        """Lazy initialization of OpenAI client configured for NVIDIA API."""
+        if self._client is None:
+            try:
+                from openai import AsyncOpenAI
+            except ImportError as e:
+                raise ImportError(
+                    "openai package required for NVIDIA NIM: pip install openai>=1.12"
+                ) from e
+
+            api_key = self._api_key or os.environ.get("NVIDIA_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "NVIDIA API key required. Set NVIDIA_API_KEY environment variable "
+                    "or pass api_key parameter."
+                )
+
+            self._client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=NVIDIA_BASE_URL,
+            )
+        return self._client
+
+    async def generate(self, prompt: str, max_tokens: int | None = None) -> str:
+        """Generate text completion for the given prompt.
+
+        Attempts to use JSON mode for structured outputs. Falls back to
+        regular chat completion if the model doesn't support JSON mode.
+
+        Args:
+            prompt: The prompt text to send to the model.
+            max_tokens: Optional maximum tokens in the response.
+
+        Returns:
+            Generated text response.
+        """
+        client = self._get_client()
+
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.1,
+        }
+
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        # Try JSON mode first (for structured extraction)
+        try:
+            kwargs["response_format"] = {"type": "json_object"}
+            response = await client.chat.completions.create(**kwargs)
+        except Exception:
+            # Fallback if model doesn't support JSON mode
+            del kwargs["response_format"]
+            response = await client.chat.completions.create(**kwargs)
+
+        return response.choices[0].message.content or ""


### PR DESCRIPTION
Added support for NVIDIA NIM (NVIDIA Inference Microservices) as a model provider for both embeddings and LLM-based fact extraction. This enables users to use GPU-optimized models hosted on NVIDIA's platform.

# Changes Made
- New file: vektori/models/nvidia.py - Complete NVIDIA NIM provider implementation
NvidiaEmbedder class with Matryoshka embedding support (384-2048 dimensions)
NvidiaLLM class for fact/episode extraction
Automatic namespace handling (nvidia/ prefix for NVIDIA models, full path for third-party models)
Support for input_type parameter on asymmetric embedding models
- Updated: vektori/models/factory.py - Added NVIDIA to embedding and LLM registries
- Updated: pyproject.toml - Added nvidia optional dependency (openai>=1.12)
- Updated: README.md - Added NVIDIA NIM documentation section
- Updated: tests/unit/test_factory.py - Added comprehensive NVIDIA tests

# Testing
✅ All 53 unit tests pass
✅ Integration tests verify actual NVIDIA API calls work correctly
✅ Matryoshka dimensions verified (384, 512, 768, 1024, 2048)
✅ Factory creation tests for all model types

# Notes
- BGE-M3 via NVIDIA NIM currently returns 500 errors (server-side issue) - users should use local BGE provider instead: vektori[embedding_model="bge:BAAI/bge-m3"]
- NVIDIA NIM uses OpenAI-compatible API (https://integrate.api.nvidia.com/v1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NVIDIA NIM GPU‑optimized embeddings and LLMs via an OpenAI‑compatible API, with configurable embedding dimensions and model name handling.

* **Documentation**
  * README updated with usage examples for NVIDIA embedding and extraction models, including dimension customization and example model strings.

* **Chores**
  * New optional "nvidia" dependency group (includes openai>=1.12) and added to the combined extras.

* **Tests**
  * Added unit tests validating NVIDIA provider creation and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->