### PR TITLE
feat: add anonymous PostHog telemetry to CLI

### DIFF
--- a/vektori/cli.py
+++ b/vektori/cli.py
@@ -237,12 +237,6 @@ def init(
     _warn_openai(em, "--extraction-model")
     _warn_openai(eb, "--embedding-model")
 
-    telemetry.capture("cli:init", {
-        "backend": storage_backend or _default_storage_backend(),
-        "extraction_provider": telemetry.provider(em),
-        "embedding_provider": telemetry.provider(eb),
-    })
-
     async def _run() -> None:
         v = _client(
             em,
@@ -300,13 +294,6 @@ def add(
     _warn_openai(eb, "--embedding-model")
     sid = session_id or str(uuid.uuid4())
     messages = [{"role": "user", "content": text}]
-
-    telemetry.capture("cli:add", {
-        "backend": storage_backend or _default_storage_backend(),
-        "extraction_provider": telemetry.provider(em),
-        "embedding_provider": telemetry.provider(eb),
-        "no_extraction": no_extraction,
-    })
 
     async def _run() -> dict:
         v = _client(
@@ -372,13 +359,6 @@ def search(
     em = extraction_model or _default_extraction()
     eb = embedding_model or _default_embedding()
     _warn_openai(eb, "--embedding-model")
-
-    telemetry.capture("cli:search", {
-        "backend": storage_backend or _default_storage_backend(),
-        "embedding_provider": telemetry.provider(eb),
-        "depth": depth,
-        "expand": expand,
-    })
 
     async def _run() -> dict:
         v = _client(
@@ -454,10 +434,6 @@ def list_memories(
     """List all active memories (extracted facts) for a user."""
     eb = embedding_model or _default_embedding()
 
-    telemetry.capture("cli:list", {
-        "backend": storage_backend or _default_storage_backend(),
-    })
-
     async def _run() -> list:
         v = _client(
             _default_extraction(),
@@ -509,10 +485,6 @@ def delete(
     """Delete all memories for a user."""
     if not yes:
         typer.confirm(f"Delete ALL memories for user '{user_id}'?", abort=True)
-
-    telemetry.capture("cli:delete", {
-        "backend": storage_backend or _default_storage_backend(),
-    })
 
     async def _run() -> int:
         v = _client(
@@ -570,12 +542,6 @@ def remember(
     _warn_openai(em, "--extraction-model")
     sid = session_id or str(uuid.uuid4())
     messages = [{"role": "user", "content": text}]
-
-    telemetry.capture("cli:remember", {
-        "backend": storage_backend or _default_storage_backend(),
-        "extraction_provider": telemetry.provider(em),
-        "embedding_provider": telemetry.provider(eb),
-    })
 
     async def _run() -> dict:
         v = _client(
@@ -637,13 +603,6 @@ def recall(
     """Recall memories. Alias for `search` — reads naturally in agent prompts."""
     em = extraction_model or _default_extraction()
     eb = embedding_model or _default_embedding()
-
-    telemetry.capture("cli:recall", {
-        "backend": storage_backend or _default_storage_backend(),
-        "embedding_provider": telemetry.provider(eb),
-        "depth": depth,
-        "synthesize": synthesize,
-    })
 
     async def _run() -> dict:
         v = _client(
@@ -746,10 +705,6 @@ def stats(
 ) -> None:
     """Show memory stats for a user."""
 
-    telemetry.capture("cli:stats", {
-        "backend": storage_backend or _default_storage_backend(),
-    })
-
     async def _run() -> dict:
         v = _client(
             _default_extraction(),
@@ -793,4 +748,5 @@ def stats(
 
 
 def main() -> None:
+    telemetry.set_interface("cli")
     app()

--- a/vektori/cli.py
+++ b/vektori/cli.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import typer
 
+from vektori import telemetry
+
 app = typer.Typer(help="Vektori memory engine — self-hosted, zero-config.", no_args_is_help=True)
 
 _CONFIG_PATH = Path.home() / ".vektori" / "config.json"
@@ -235,6 +237,12 @@ def init(
     _warn_openai(em, "--extraction-model")
     _warn_openai(eb, "--embedding-model")
 
+    telemetry.capture("cli:init", {
+        "backend": storage_backend or _default_storage_backend(),
+        "extraction_provider": telemetry.provider(em),
+        "embedding_provider": telemetry.provider(eb),
+    })
+
     async def _run() -> None:
         v = _client(
             em,
@@ -292,6 +300,13 @@ def add(
     _warn_openai(eb, "--embedding-model")
     sid = session_id or str(uuid.uuid4())
     messages = [{"role": "user", "content": text}]
+
+    telemetry.capture("cli:add", {
+        "backend": storage_backend or _default_storage_backend(),
+        "extraction_provider": telemetry.provider(em),
+        "embedding_provider": telemetry.provider(eb),
+        "no_extraction": no_extraction,
+    })
 
     async def _run() -> dict:
         v = _client(
@@ -357,6 +372,13 @@ def search(
     em = extraction_model or _default_extraction()
     eb = embedding_model or _default_embedding()
     _warn_openai(eb, "--embedding-model")
+
+    telemetry.capture("cli:search", {
+        "backend": storage_backend or _default_storage_backend(),
+        "embedding_provider": telemetry.provider(eb),
+        "depth": depth,
+        "expand": expand,
+    })
 
     async def _run() -> dict:
         v = _client(
@@ -432,6 +454,10 @@ def list_memories(
     """List all active memories (extracted facts) for a user."""
     eb = embedding_model or _default_embedding()
 
+    telemetry.capture("cli:list", {
+        "backend": storage_backend or _default_storage_backend(),
+    })
+
     async def _run() -> list:
         v = _client(
             _default_extraction(),
@@ -483,6 +509,10 @@ def delete(
     """Delete all memories for a user."""
     if not yes:
         typer.confirm(f"Delete ALL memories for user '{user_id}'?", abort=True)
+
+    telemetry.capture("cli:delete", {
+        "backend": storage_backend or _default_storage_backend(),
+    })
 
     async def _run() -> int:
         v = _client(
@@ -540,6 +570,12 @@ def remember(
     _warn_openai(em, "--extraction-model")
     sid = session_id or str(uuid.uuid4())
     messages = [{"role": "user", "content": text}]
+
+    telemetry.capture("cli:remember", {
+        "backend": storage_backend or _default_storage_backend(),
+        "extraction_provider": telemetry.provider(em),
+        "embedding_provider": telemetry.provider(eb),
+    })
 
     async def _run() -> dict:
         v = _client(
@@ -601,6 +637,13 @@ def recall(
     """Recall memories. Alias for `search` — reads naturally in agent prompts."""
     em = extraction_model or _default_extraction()
     eb = embedding_model or _default_embedding()
+
+    telemetry.capture("cli:recall", {
+        "backend": storage_backend or _default_storage_backend(),
+        "embedding_provider": telemetry.provider(eb),
+        "depth": depth,
+        "synthesize": synthesize,
+    })
 
     async def _run() -> dict:
         v = _client(
@@ -702,6 +745,10 @@ def stats(
     as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Show memory stats for a user."""
+
+    telemetry.capture("cli:stats", {
+        "backend": storage_backend or _default_storage_backend(),
+    })
 
     async def _run() -> dict:
         v = _client(

--- a/vektori/client.py
+++ b/vektori/client.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from vektori import telemetry
 from vektori.config import ExtractionConfig, QualityConfig, VektoriConfig
 
 logger = logging.getLogger(__name__)
@@ -138,6 +139,11 @@ class Vektori:
 
         self._initialized = True
         logger.info("Vektori initialized (backend=%s)", self.config.storage_backend)
+        telemetry.capture("vektori:init", {
+            "backend": self.config.storage_backend,
+            "extraction_provider": telemetry.provider(self.config.extraction_model),
+            "embedding_provider": telemetry.provider(self.config.embedding_model),
+        })
 
     async def add(
         self,
@@ -169,6 +175,12 @@ class Vektori:
             {"status": "ok", "sentences_stored": N, "extraction": "queued"|"done"|"skipped"}
         """
         await self._ensure_initialized()
+
+        telemetry.capture("vektori:add", {
+            "backend": self.config.storage_backend,
+            "skip_extraction": skip_extraction,
+            "async_extraction": self.config.async_extraction,
+        })
 
         result = await self._pipeline.ingest(
             messages, session_id, user_id, agent_id, metadata, session_time=session_time,
@@ -220,6 +232,11 @@ class Vektori:
         Maps source:source_id -> deterministic session_id so re-ingestion upserts, not duplicates.
         """
         session_id = f"{source}:{source_id}"
+
+        telemetry.capture("vektori:add_document", {
+            "backend": self.config.storage_backend,
+            "source": source,
+        })
 
         doc_metadata = metadata or {}
         doc_metadata.update({
@@ -305,6 +322,12 @@ class Vektori:
             }
         """
         await self._ensure_initialized()
+
+        telemetry.capture("vektori:search", {
+            "backend": self.config.storage_backend,
+            "depth": depth,
+            "expand": expand,
+        })
 
         if self.config.enable_retrieval_gate:
             from vektori.retrieval.gate import should_retrieve

--- a/vektori/telemetry.py
+++ b/vektori/telemetry.py
@@ -1,0 +1,141 @@
+"""Anonymous usage telemetry for Vektori CLI.
+
+Events are fire-and-forget (daemon thread, 3s timeout).
+Skipped entirely when:
+  - VEKTORI_NO_TELEMETRY=1  (or DO_NOT_TRACK=1)
+  - running inside a known CI/CD environment
+  - the PostHog API key is still the placeholder
+
+Replace _POSTHOG_API_KEY with your project's key from PostHog → Project Settings → API Keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+import threading
+import uuid
+from pathlib import Path
+from typing import Any
+
+_POSTHOG_API_KEY = "phc_REPLACE_WITH_YOUR_KEY"
+_POSTHOG_HOST = "https://us.i.posthog.com"
+_CONFIG_PATH = Path.home() / ".vektori" / "config.json"
+
+_NOTICE = (
+    "[vektori] Anonymous usage stats are collected to improve the project. "
+    "Opt out: VEKTORI_NO_TELEMETRY=1  "
+    "Details: https://github.com/vektori-ai/vektori#telemetry"
+)
+
+# Known CI/CD environment variables — if any are set we skip telemetry entirely.
+_CI_VARS = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "CIRCLECI",
+    "TRAVIS",
+    "JENKINS_URL",
+    "BUILDKITE",
+    "DRONE",
+    "GITLAB_CI",
+    "TF_BUILD",
+    "BITBUCKET_BUILD_NUMBER",
+    "TEAMCITY_VERSION",
+)
+
+
+def _is_ci() -> bool:
+    return any(os.environ.get(v) for v in _CI_VARS)
+
+
+def _is_disabled() -> bool:
+    return bool(
+        os.environ.get("VEKTORI_NO_TELEMETRY")
+        or os.environ.get("DO_NOT_TRACK")
+        or _POSTHOG_API_KEY == "phc_REPLACE_WITH_YOUR_KEY"
+    )
+
+
+def _load_cfg() -> dict:
+    if _CONFIG_PATH.exists():
+        try:
+            return json.loads(_CONFIG_PATH.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def _save_cfg(data: dict) -> None:
+    _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CONFIG_PATH.write_text(json.dumps(data, indent=2))
+
+
+def _get_or_create_install_id() -> str | None:
+    try:
+        cfg = _load_cfg()
+        if "install_id" not in cfg:
+            cfg["install_id"] = str(uuid.uuid4())
+            _save_cfg(cfg)
+        return cfg["install_id"]
+    except Exception:
+        return None
+
+
+def _maybe_show_notice() -> None:
+    try:
+        cfg = _load_cfg()
+        if not cfg.get("telemetry_notice_shown"):
+            import typer
+            typer.echo(_NOTICE, err=True)
+            cfg["telemetry_notice_shown"] = True
+            _save_cfg(cfg)
+    except Exception:
+        pass
+
+
+def _pkg_version() -> str:
+    try:
+        from vektori._version import version
+        return version
+    except Exception:
+        return "unknown"
+
+
+def capture(event: str, properties: dict[str, Any] | None = None) -> None:
+    """Fire a telemetry event asynchronously. Never raises."""
+    if _is_disabled() or _is_ci():
+        return
+
+    _maybe_show_notice()
+    install_id = _get_or_create_install_id()
+    if not install_id:
+        return
+
+    payload = {
+        "api_key": _POSTHOG_API_KEY,
+        "event": event,
+        "distinct_id": install_id,
+        "properties": {
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+            "platform": platform.system().lower(),
+            "pkg_version": _pkg_version(),
+            **(properties or {}),
+        },
+    }
+
+    def _fire() -> None:
+        try:
+            import httpx
+            with httpx.Client(timeout=3.0) as client:
+                client.post(f"{_POSTHOG_HOST}/capture/", json=payload)
+        except Exception:
+            pass
+
+    threading.Thread(target=_fire, daemon=True).start()
+
+
+def provider(model: str) -> str:
+    """Extract provider prefix from a model string, e.g. 'litellm:groq/...' → 'litellm'."""
+    return model.split(":")[0] if ":" in model else model

--- a/vektori/telemetry.py
+++ b/vektori/telemetry.py
@@ -20,7 +20,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-_POSTHOG_API_KEY = "phc_REPLACE_WITH_YOUR_KEY"
+_POSTHOG_API_KEY = "phc_J6J05uIXjo0Ii3rUFXfzMUB7qxfgKtHSOUE1xCMTCWt"
 _POSTHOG_HOST = "https://us.i.posthog.com"
 _CONFIG_PATH = Path.home() / ".vektori" / "config.json"
 
@@ -64,7 +64,6 @@ def _is_disabled() -> bool:
     return bool(
         os.environ.get("VEKTORI_NO_TELEMETRY")
         or os.environ.get("DO_NOT_TRACK")
-        or _POSTHOG_API_KEY == "phc_REPLACE_WITH_YOUR_KEY"
     )
 
 

--- a/vektori/telemetry.py
+++ b/vektori/telemetry.py
@@ -24,6 +24,16 @@ _POSTHOG_API_KEY = "phc_REPLACE_WITH_YOUR_KEY"
 _POSTHOG_HOST = "https://us.i.posthog.com"
 _CONFIG_PATH = Path.home() / ".vektori" / "config.json"
 
+# Set by CLI at startup so client-level events know they came from the CLI.
+# Default is "sdk" — used when Vektori is imported directly in Python code.
+_interface: str = "sdk"
+
+
+def set_interface(name: str) -> None:
+    """Call once at process startup to tag all subsequent events with the interface name."""
+    global _interface
+    _interface = name
+
 _NOTICE = (
     "[vektori] Anonymous usage stats are collected to improve the project. "
     "Opt out: VEKTORI_NO_TELEMETRY=1  "
@@ -121,6 +131,7 @@ def capture(event: str, properties: dict[str, Any] | None = None) -> None:
             "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
             "platform": platform.system().lower(),
             "pkg_version": _pkg_version(),
+            "interface": _interface,
             **(properties or {}),
         },
     }


### PR DESCRIPTION
Closes #63

## What this does

Adds lightweight opt-out telemetry to the Vektori CLI using PostHog. Every CLI invocation fires a single background HTTP event (daemon thread, 3 s timeout) so we can see which commands, backends, and model providers people are actually using — without collecting any PII.

## What's collected

| Property | Example |
|---|---|
| Command | `cli:add`, `cli:recall`, `cli:search`, … |
| Backend | `sqlite`, `postgres`, `qdrant`, … |
| Extraction provider | `litellm`, `openai`, `anthropic` |
| Embedding provider | `sentence-transformers`, `openai` |
| Python version | `3.11` |
| Platform | `linux` / `darwin` / `windows` |
| Package version | `0.1.2` |
| Install ID | random UUID in `~/.vektori/config.json` |

No query text, no memory content, no user IDs.

## CI/CD filtering

Events are **skipped entirely** when `CI`, `GITHUB_ACTIONS`, `CIRCLECI`, `TRAVIS`, `JENKINS_URL`, `BUILDKITE`, `DRONE`, `GITLAB_CI`, `TF_BUILD`, `BITBUCKET_BUILD_NUMBER`, or `TEAMCITY_VERSION` is set — so PostHog only shows real humans, not pipeline runs.

## Opt-out

```bash
export VEKTORI_NO_TELEMETRY=1   # or DO_NOT_TRACK=1
```

First-run notice printed once to stderr, then silenced via `~/.vektori/config.json`.

## Before merging

Replace `phc_REPLACE_WITH_YOUR_KEY` in [vektori/telemetry.py](vektori/telemetry.py) with your PostHog project API key (Project Settings → API Keys).

## No new dependencies

Uses `httpx` which is already a required dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client now emits anonymous telemetry for key actions (init, add, add_document, search), recording backend/provider and selected runtime parameters to help improve behavior.

* **Chores**
  * Added opt-out anonymous usage telemetry for the CLI with a one-time notice. Telemetry respects VEKTORI_NO_TELEMETRY/DO_NOT_TRACK and common CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->